### PR TITLE
new function `fitlm` and various minor bug fixes in `anovan`

### DIFF
--- a/inst/anovan.m
+++ b/inst/anovan.m
@@ -240,7 +240,7 @@ function [P, T, STATS, TERMS] = anovan (Y, GROUP, varargin)
 
     ## Check supplied parameters
     if ((numel (varargin) / 2) != fix (numel (varargin) / 2))
-      error ("wrong number of arguments.")
+      error ("anovan: wrong number of arguments.")
     endif
     MODELTYPE = "linear";
     DISPLAY = "on";
@@ -262,7 +262,7 @@ function [P, T, STATS, TERMS] = anovan (Y, GROUP, varargin)
         case "random"
           RANDOM = value;
         case "nested"
-          error (strcat (["nested ANOVA is not supported. Please use"], ...
+          error (strcat (["anovan: nested ANOVA is not supported. Please use"], ...
                          [" anova2 for fully balanced nested ANOVA designs."]));
         case "sstype"
           SSTYPE = value;
@@ -277,18 +277,18 @@ function [P, T, STATS, TERMS] = anovan (Y, GROUP, varargin)
         case "weights"
           WEIGHTS = value;
         otherwise
-          error (sprintf ("parameter %s is not supported", name));
+          error (sprintf ("anovan: parameter %s is not supported", name));
       endswitch
     endfor
 
     ## Evaluate continuous input argument
     if (isnumeric (CONTINUOUS))
       if (any (CONTINUOUS != abs (fix (CONTINUOUS))))
-        error (strcat (["the value provided for the CONTINUOUS"], ...
+        error (strcat (["anovan: the value provided for the CONTINUOUS"], ...
                        [" parameter must be a positive integer"]));
       endif
     else
-      error (strcat (["the value provided for the CONTINUOUS"], ...
+      error (strcat (["anovan: the value provided for the CONTINUOUS"], ...
                      [" parameter must be numeric"]));
     endif
 
@@ -298,14 +298,14 @@ function [P, T, STATS, TERMS] = anovan (Y, GROUP, varargin)
     N = size (GROUP, 2); # number of anova "ways"
     n = numel (Y);      # total number of observations
     if (prod (size (Y)) != n)
-      error ("for ""anovan (Y, GROUP)"", Y must be a vector");
+      error ("anovan: for ""anovan (Y, GROUP)"", Y must be a vector");
     endif
     if (numel (unique (CONTINUOUS)) > N)
-      error (strcat (["the number of factors assigned as continuous"], ...
+      error (strcat (["anovan: the number of factors assigned as continuous"], ...
                  [" cannot exceed the number of factors in GROUP"]));
     endif
     if (any ((CONTINUOUS > N) || any (CONTINUOUS <= 0)))
-      error (strcat (["one or more indices provided in the value"], ...
+      error (strcat (["anovan: one or more indices provided in the value"], ...
                  [" for the continuous parameter are out of range"]));
     endif
     cont_vec = false (1, N);
@@ -322,7 +322,7 @@ function [P, T, STATS, TERMS] = anovan (Y, GROUP, varargin)
             endif
           else
             if (ismember (j, CONTINUOUS))
-              error ("continuous factors must be a numeric datatype");
+              error ("anovan: continuous factors must be a numeric datatype");
             endif
             tmp(:,j) = GROUP{j};
           endif
@@ -332,7 +332,7 @@ function [P, T, STATS, TERMS] = anovan (Y, GROUP, varargin)
     endif
     if (! isempty (GROUP))
       if (size (GROUP,1) != n)
-        error ("GROUP must be a matrix with the same number of rows as Y");
+        error ("anovan: GROUP must be a matrix with the same number of rows as Y");
       endif
     endif
     if (! isempty (VARNAMES))
@@ -340,7 +340,7 @@ function [P, T, STATS, TERMS] = anovan (Y, GROUP, varargin)
         if (all (cellfun (@ischar, VARNAMES)))
           nvarnames = numel(VARNAMES);
         else
-          error (strcat (["all variable names must be character"], ...
+          error (strcat (["anovan: all variable names must be character"], ...
                          [" or character arrays"]));
         endif
       elseif (ischar (VARNAMES))
@@ -350,7 +350,7 @@ function [P, T, STATS, TERMS] = anovan (Y, GROUP, varargin)
         nvarnames = 1;
         VARNAMES = {char(VARNAMES)};
       else
-        error (strcat (["varnames is not of a valid type. Must be a cell"], ...
+        error (strcat (["anovan: varnames is not of a valid type. Must be a cell"], ...
                [" array of character arrays, character array or string"]));
       endif
     else
@@ -358,7 +358,7 @@ function [P, T, STATS, TERMS] = anovan (Y, GROUP, varargin)
       VARNAMES = arrayfun(@(x) ["X",num2str(x)], 1:N, "UniformOutput", 0);
     endif
     if (nvarnames != N)
-      error (strcat (["number of variable names is not equal"], ...
+      error (strcat (["anovan: number of variable names is not equal"], ...
                      ["  to number of grouping variables"]));
     endif
 
@@ -366,19 +366,19 @@ function [P, T, STATS, TERMS] = anovan (Y, GROUP, varargin)
     if (! isempty(RANDOM))
       if (isnumeric (RANDOM))
         if (any (RANDOM != abs (fix (RANDOM))))
-          error (strcat (["the value provided for the RANDOM"], ...
+          error (strcat (["anovan: the value provided for the RANDOM"], ...
                          [" parameter must be a positive integer"]));
         endif
       else
-        error (strcat (["the value provided for the RANDOM"], ...
+        error (strcat (["anovan: the value provided for the RANDOM"], ...
                      ["  parameter must be numeric"]));
       endif
       if (numel (RANDOM) > N)
-        error (strcat (["the number of elements in RANDOM cannot"], ...
+        error (strcat (["anovan: the number of elements in RANDOM cannot"], ...
                [" exceed the number of columns in GROUP."]));
       endif
       if (max (RANDOM) > N)
-        error (strcat (["the indices listed in RANDOM cannot"], ...
+        error (strcat (["anovan: the indices listed in RANDOM cannot"], ...
                [" exceed the number of columns in GROUP."]));
       endif
       for v = 1:N
@@ -415,7 +415,7 @@ function [P, T, STATS, TERMS] = anovan (Y, GROUP, varargin)
           else
             if (! ismember (CONTRASTS{i}, ...
                             {"simple","poly","helmert","effect","treatment"}))
-              error (strcat(["the choices for built-in contrasts are"], ...
+              error (strcat(["anovan: the choices for built-in contrasts are"], ...
                      [" ""simple"", ""poly"", ""helmert"", ""effect"", or ""treatment"""]));
             endif
             if (strcmpi (CONTRASTS{i}, "treatment") && (SSTYPE==3))
@@ -430,10 +430,10 @@ function [P, T, STATS, TERMS] = anovan (Y, GROUP, varargin)
 
     ## Evaluate alpha input argument
     if (! isa (ALPHA,'numeric') || numel (ALPHA) != 1)
-      error("anovan:alpha must be a numeric scalar value");
+      error("anovan: alpha must be a numeric scalar value");
     end
     if ((ALPHA <= 0) || (ALPHA >= 1))
-      error("alpha must be a value between 0 and 1");
+      error("anovan: alpha must be a value between 0 and 1");
     end
 
     ## Remove NaN or non-finite observations
@@ -456,13 +456,13 @@ function [P, T, STATS, TERMS] = anovan (Y, GROUP, varargin)
     ## Evaluate weights input argument
     if (! isempty(WEIGHTS))
       if (! isnumeric(WEIGHTS))
-        error ("WEIGHTS must be a numeric datatype");
+        error ("anovan: WEIGHTS must be a numeric datatype");
       endif
       if (any (size (WEIGHTS) != [n,1]))
-        error ("WEIGHTS must be a vector with the same dimensions as Y");
+        error ("anovan: WEIGHTS must be a vector with the same dimensions as Y");
       endif
       if (any(!(WEIGHTS > 0)) || any (isinf (WEIGHTS)))
-        error ("WEIGHTS must be a vector of positive finite values");
+        error ("anovan: WEIGHTS must be a vector of positive finite values");
       endif
       # Create diaganal matrix of normalized weights
       W = diag (WEIGHTS / mean (WEIGHTS));
@@ -472,7 +472,7 @@ function [P, T, STATS, TERMS] = anovan (Y, GROUP, varargin)
     endif
 
     ## Evaluate model type input argument and create terms matrix if not provided
-    msg = strcat (["the number of columns in the term definitions"], ...
+    msg = strcat (["anovan: the number of columns in the term definitions"], ...
                   [" cannot exceed the number of columns of GROUP"]);
     if (ischar (MODELTYPE))
       switch (lower (MODELTYPE))
@@ -483,7 +483,7 @@ function [P, T, STATS, TERMS] = anovan (Y, GROUP, varargin)
         case "full"
           MODELTYPE = N;
         otherwise
-          error ("model type not recognised");
+          error ("anovan: model type not recognised");
       endswitch
     endif
     if (isscalar (MODELTYPE))
@@ -531,7 +531,7 @@ function [P, T, STATS, TERMS] = anovan (Y, GROUP, varargin)
         error (msg);
       endif
       if (! all (ismember (MODELTYPE(:), [0,1])))
-        error (strcat (["elements of the model terms matrix"], ...
+        error (strcat (["anovan: elements of the model terms matrix"], ...
                        [" must be either 0 or 1"]));
       endif
       TERMS = logical (MODELTYPE);
@@ -539,7 +539,7 @@ function [P, T, STATS, TERMS] = anovan (Y, GROUP, varargin)
     ## Evaluate terms matrix
     Ng = sum (TERMS, 2);
     if (any (diff (Ng) < 0))
-      error (strcat (["the model terms matrix must list main"], ...
+      error (strcat (["anovan: the model terms matrix must list main"], ...
                      [" effects above/before interactions"]));
     endif
     ## Drop terms that include interactions with factors specified as random effects.
@@ -551,7 +551,7 @@ function [P, T, STATS, TERMS] = anovan (Y, GROUP, varargin)
     Nx = sum (Ng > 1);
     Nt = Nm + Nx;
     if (any (any (TERMS(1:Nm,:), 1) != any (TERMS, 1)))
-      error (strcat (["all factors involved in interactions"], ...
+      error (strcat (["anovan: all factors involved in interactions"], ...
                      [" must have a main effect"]));
     endif
 
@@ -603,7 +603,7 @@ function [P, T, STATS, TERMS] = anovan (Y, GROUP, varargin)
         endfor
         sstype_char = "III";
       otherwise
-        error ("sstype value not supported");
+        error ("anovan: sstype value not supported");
     endswitch
     ss = max (0, ss); # Truncate negative SS at 0 
     dfe = dft - sum (df);
@@ -797,7 +797,7 @@ function [P, T, STATS, TERMS] = anovan (Y, GROUP, varargin)
 
       otherwise
 
-        error ("wrong value for 'display' parameter.");
+        error ("anovan: wrong value for 'display' parameter.");
 
     endswitch
 
@@ -904,16 +904,16 @@ function [P, T, STATS, TERMS] = anovan (Y, GROUP, varargin)
                 ## EVALUATE CUSTOM CONTRAST MATRIX
                 ## Check that the contrast matrix provided is the correct size
                 if (! all (size (CONTRASTS{j},1) == nlevels(j)))
-                  error (strcat (["the number of rows in the contrast"], ...
+                  error (strcat (["anovan: the number of rows in the contrast"], ...
                                [" matrices should equal the number of factor levels"]));
                 endif
                 if (! all (size (CONTRASTS{j},2) == df(j)))
-                  error (strcat (["the number of columns in each contrast"], ...
+                  error (strcat (["anovan: the number of columns in each contrast"], ...
                           [" matrix should equal the degrees of freedom (i.e."], ...
                           [" number of levels minus 1) for that factor"]));
                 endif
                 if (! all (any (CONTRASTS{j})))
-                  error (strcat (["a contrast must be coded in each"], ...
+                  error (strcat (["anovan: a contrast must be coded in each"], ...
                                  [" column of the contrast matrices"]));
                 endif
             endswitch

--- a/inst/fitlm.m
+++ b/inst/fitlm.m
@@ -136,7 +136,7 @@ function [T, STATS] = fitlm (X, y, varargin)
                       [" atleast 2 input arguments required"]));
     endif
     if (nargout > 3)
-      error ("invalid number of output arguments requested");
+      error ("fitlm: invalid number of output arguments requested");
     endif
 
     ## Evaluate input data 
@@ -170,11 +170,11 @@ function [T, STATS] = fitlm (X, y, varargin)
     if (ischar (MODELSPEC))
       MODELSPEC = lower (MODELSPEC);
       if (! isempty (regexp (MODELSPEC, "~")))
-        error ("model formulae are not a supported format for MODELSPEC")
+        error ("fitlm: model formulae are not a supported format for MODELSPEC")
       endif
       if (! ismember (MODELSPEC, {"constant", "linear", "interaction", ...
                                   "interactions", "full"}))
-        error ("character vector for model specification not recognised")
+        error ("fitlm: character vector for model specification not recognised")
       endif
       if strcmp (MODELSPEC, "constant") 
         X = [];
@@ -184,13 +184,13 @@ function [T, STATS] = fitlm (X, y, varargin)
       endif
     else
       if (size (MODELSPEC, 1) < N + 1)
-        error ("number of rows in MODELSPEC must  1 + number of columns in X");
+        error ("fitlm: number of rows in MODELSPEC must  1 + number of columns in X");
       endif
       if (size (MODELSPEC, 2) != N + 1)
-        error ("number of columns in MODELSPEC must = 1 + number of columns in X");
+        error ("fitlm: number of columns in MODELSPEC must = 1 + number of columns in X");
       endif
       if (! all (ismember (MODELSPEC(:), [0,1])))
-        error (strcat (["elements of the model terms matrix must be "], ...
+        error (strcat (["fitlm: elements of the model terms matrix must be "], ...
                        [" either 0 or 1. Higher order terms are not supported"]));
       endif
       MODELSPEC = logical (MODELSPEC(2:N+1,1:N));
@@ -198,8 +198,8 @@ function [T, STATS] = fitlm (X, y, varargin)
 
     ## Check for unsupported options used by anovan
     if (any (strcmpi ("MODEL", options)))
-      error (strcat(["modelspec should be specified in the third input"], ...
-                    [" argument of fitlm (if at all)"]));
+      error (strcat(["fitlm: modelspec should be specified in the third"], ...
+                    [" input argument of fitlm (if at all)"]));
     endif
 
     ## Check and set variable types
@@ -238,7 +238,7 @@ function [T, STATS] = fitlm (X, y, varargin)
           if (! isempty (CONTRASTS{i}))
             if (! ismember (CONTRASTS{i}, ...
                             {"simple","poly","helmert","effect","treatment"}))
-              error (strcat(["anovan: the choices for built-in contrasts are"], ...
+              error (strcat(["fitlm: the choices for built-in contrasts are"], ...
                      [" ""simple"", ""poly"", ""helmert"", ""effect"", or ""treatment"""]));
             endif
           endif

--- a/inst/fitlm.m
+++ b/inst/fitlm.m
@@ -1,0 +1,397 @@
+## Copyright (C) 2022 Andrew Penn <A.C.Penn@sussex.ac.uk>
+##
+## This file is part of the statistics package for GNU Octave.
+##
+## This program is free software; you can redistribute it and/or modify it under
+## the terms of the GNU General Public License as published by the Free Software
+## Foundation; either version 3 of the License, or (at your option) any later
+## version.
+##
+## This program is distributed in the hope that it will be useful, but WITHOUT
+## ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+## FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+## details.
+##
+## You should have received a copy of the GNU General Public License along with
+## this program; if not, see <http://www.gnu.org/licenses/>.
+
+## -*- texinfo -*-
+## @deftypefn {Function File} @var{p} = fitlm (@var{X}, @var{y})
+## @deftypefnx {Function File} @var{p} = fitlm (@var{X}, @var{y}, "name", @var{value})
+## @deftypefnx {Function File} @var{p} = fitlm (@var{X}, @var{y}, @var{modelspec})
+## @deftypefnx {Function File} @var{p} = fitlm (@var{X}, @var{y}, @var{modelspec}, "name", @var{value})
+## @deftypefnx {Function File} [@var{p}, @var{tab}] = fitlm (...)
+## @deftypefnx {Function File} [@var{p}, @var{tab}, @var{stats}] = fitlm (...)
+## @deftypefnx {Function File} [@var{p}, @var{tab}, @var{stats}, @var{modelspec}] = fitlm (...)
+##
+## Regress the continuous outcome (i.e. dependent variable) @var{y} on
+## continuous or categorical predictors (i.e. independent variables) @var{X}
+## by minimizing the sum-of-squared residuals. Unless requested otherwise,
+## @qcode{fitlm} prints the model formula, the regression coefficients (i.e. 
+## parameters/contrasts) and an ANOVA table. Note that unlike @qcode{anovan}, 
+## @qcode{fitlm} treats all factors as continuous by default. 
+##
+## @var{X} must be a column major matrix or cell array consisting of the
+## predictors. By default, there is a constant term in the model, unless you,
+## explicitly remove it, so do not include a column of 1s in X. @var{y} must be
+## a column vector corresponding to the outcome variable. @var{modelspec} can
+## specified as one of the following:
+##
+## @itemize
+## @item
+## "constant" : model contains only a constant (intercept) term.
+##
+## @item
+## "linear" (default) : model contains an intercept and linear term for each
+## predictor.
+##
+## @item
+## "interactions" : model contains an intercept, linear term for each predictor
+## and all products of pairs of distinct predictors.
+##
+## @item
+## "full" : model contains an intercept, linear term for each predictor and
+## all combinations of the predictors.
+##
+## @item
+## a matrix of term definitions : an t-by-(N+1) matrix specifying terms in
+## a model, where t is the number of terms, N is the number of predictor 
+## variables, and +1 accounts for the outcome variable. The outcome variable
+## is the last column in the terms matrix and must be a column of zeros.
+## An intercept must be specified in the first row of the terms matrix and
+## must be a row of zeros.
+## @end itemize
+##
+## @qcode{fitlm} can take a number of optional parameters as name-value pairs.
+##
+## @code{[@dots{}] = fitlm (..., "CategoricalVars", @var{categorical})}
+##
+## @itemize
+## @item
+## @var{categorical} is a vector of indices indicating which of the columns 
+## (i.e. variables) in @var{X} should be treated as categorical predictors
+## rather than as continuous predictors. 
+## @end itemize
+##
+## @qcode{fitlm} also accepts optional @qcode{anovan} parameters as name-value
+## pairs (except for the "model" parameter). The accepted parameter names from
+## @qcode{anovan} and their default values in @qcode{fitlm} are:
+##
+## @itemize
+## @item
+## @var{CONTRASTS} : "treatment"
+##
+## @item
+## @var{SSTYPE}: 2
+##
+## @item
+## @var{ALPHA}: 0.05
+##
+## @item
+## @var{DISPLAY}: "on"
+##
+## @item
+## @var{WEIGHTS}: [] (empty)
+##
+## @item
+## @var{RANDOM}: [] (empty)
+##
+## @item
+## @var{CONTINUOUS}: [1:N]
+##
+## @item
+## @var{VARNAMES}: [] (empty)
+## @end itemize
+##
+## Type '@qcode{help anovan}' to find out more about what these options do.
+##
+## @qcode{fitlm} can return up to two output arguments:
+##
+## [@var{tab}] = fitlm (@dots{}) returns a cell array containing a
+## table of model parameters
+##
+## [@var{tab}, @var{stats}] = fitlm (@dots{}) returns a structure
+## containing additional statistics, including degrees of freedom and effect
+## sizes for each term in the linear model, the design matrix, the
+## variance-covariance matrix, (weighted) model residuals, and the mean squared
+## error. The columns of @var{stats}.coeffs (from left-to-right) report the
+## model coefficients, standard errors, lower and upper 100*(1-alpha)%
+## confidence interval bounds, t-statistics, and p-values relating to the
+## contrasts. The number appended to each term name in @var{stats}.coeffnames
+## corresponds to the column number in the relevant contrast matrix for that
+## factor. The @var{stats} structure can be used as input for @qcode{multcompare}.
+## Note that if the model contains a continuous variable and you wish to use
+## the @var{STATS} output as input to @qcode{multcompare}, it needs to be
+## refit with "contrast" parameter set to sum-to-zero contrast coding scheme,
+## e.g."simple".
+##
+## @seealso{anovan, multcompare}
+## @end deftypefn
+
+function [T, STATS] = fitlm (X, y, varargin)
+
+    ## Check input and output arguments
+    if (nargin < 2)
+      error (strcat (["fitlm usage: ""fitlm (X, y, varargin)""; "], ...
+                      [" atleast 2 input arguments required"]));
+    endif
+    if (nargout > 3)
+      error ("invalid number of output arguments requested");
+    endif
+
+    ## Evaluate input data 
+    [n, N] = size (X);
+
+    ## Fetch anovan options
+    options = varargin;
+    if (isempty(options))
+      options{1} = "linear";
+    endif
+
+    ## Check if MODELSPEC was provided. If not create it.
+    if (ischar (options{1}))
+      if (! ismember (lower (options{1}), {"sstype", "varnames", "contrasts", ...
+                    "weights", "alpha", "display", "continuous", ...
+                    "categorical", "categoricalvars", "random", "model"}))
+        MODELSPEC = options{1};
+        options(1) = [];
+        CONTINUOUS = [];
+      else
+        ## If MODELSPEC is not provided, set it for an additive linear model  
+        MODELSPEC = zeros (N + 1);
+        MODELSPEC(2:N+1, 1:N) = eye (N);
+      end
+    else
+      MODELSPEC = options{1};
+      options(1) = [];
+    endif
+
+    ## Evaluate MODELSPEC
+    if (ischar (MODELSPEC))
+      MODELSPEC = lower (MODELSPEC);
+      if (! isempty (regexp (MODELSPEC, "~")))
+        error ("model formulae are not a supported format for MODELSPEC")
+      endif
+      if (! ismember (MODELSPEC, {"constant", "linear", "interaction", ...
+                                  "interactions", "full"}))
+        error ("character vector for model specification not recognised")
+      endif
+      if strcmp (MODELSPEC, "constant") 
+        X = [];
+        MODELSPEC = "linear";
+        N = 0;
+        
+      endif
+    else
+      if (size (MODELSPEC, 1) < N + 1)
+        error ("number of rows in MODELSPEC must  1 + number of columns in X");
+      endif
+      if (size (MODELSPEC, 2) != N + 1)
+        error ("number of columns in MODELSPEC must = 1 + number of columns in X");
+      endif
+      if (! all (ismember (MODELSPEC(:), [0,1])))
+        error (strcat (["elements of the model terms matrix must be "], ...
+                       [" either 0 or 1. Higher order terms are not supported"]));
+      endif
+      MODELSPEC = logical (MODELSPEC(2:N+1,1:N));
+    endif
+
+    ## Check for unsupported options used by anovan
+    if (any (strcmpi ("MODEL", options)))
+      error (strcat(["modelspec should be specified in the third input"], ...
+                    [" argument of fitlm (if at all)"]));
+    endif
+
+    ## Check and set variable types
+    idx = find (any (cat (1, strcmpi ("categorical", options), ...
+                     strcmpi ("categoricalvars", options))));
+    if (! isempty (idx))
+      CONTINUOUS = [1:N];
+      CONTINUOUS(ismember(CONTINUOUS,options{idx+1})) = [];
+      options(idx:idx+1) = [];
+    else
+      CONTINUOUS = [1:N];
+    endif
+    idx = find (strcmpi ("continuous", options));
+    if (! isempty (idx))
+      ## Note that setting continuous parameter will override settings made
+      ## to "categorical"
+      CONTINUOUS = options{idx+1};
+    endif
+
+    ## Check if anovan CONTRASTS option was used
+    idx = find (strcmpi ("contrasts", options));
+    if (isempty (idx))
+      CONTRASTS = "treatment";
+    else
+      CONTRASTS = options{idx+1};
+      if (ischar(CONTRASTS))
+        contr_str = CONTRASTS;
+        CONTRASTS = cell (1, N);
+        CONTRASTS(:) = {contr_str};
+      endif
+      if (! iscell (CONTRASTS))
+        CONTRASTS = {CONTRASTS};
+      endif
+      for i = 1:N
+        if (! isnumeric(CONTRASTS{i}))
+          if (! isempty (CONTRASTS{i}))
+            if (! ismember (CONTRASTS{i}, ...
+                            {"simple","poly","helmert","effect","treatment"}))
+              error (strcat(["anovan: the choices for built-in contrasts are"], ...
+                     [" ""simple"", ""poly"", ""helmert"", ""effect"", or ""treatment"""]));
+            endif
+          endif
+        endif
+      endfor
+    endif
+
+    ## Check if anovan SSTYPE option was used
+    idx = find (strcmpi ("sstype", options));
+    if (isempty (idx))
+      SSTYPE = 2;
+    else
+      SSTYPE = options{idx+1};
+    endif
+
+    ## Perform model fit and ANOVA
+    [jnk, jnk, STATS] = anovan (y, X, options{:}, ...
+                            "model", MODELSPEC, ...
+                            "contrasts", CONTRASTS, ...
+                            "continuous", CONTINUOUS, ...
+                            "sstype", SSTYPE);
+
+    ## Create table of regression coefficients
+    ncoeff = sum (STATS.df);
+    T = cell (2 + ncoeff, 7);
+    T(1,:) = {"Parameter", "Estimate", "SE", "Lower.CI", "Upper.CI", "t", "Prob>|t|"};
+    T(2:end,1) = STATS.coeffnames;
+    T(2:end,2:7) = num2cell (STATS.coeffs);
+
+    ## Update STATS structure
+    STATS.source = "fitlm";
+
+endfunction
+
+%!demo
+%! y =  [ 8.706 10.362 11.552  6.941 10.983 10.092  6.421 14.943 15.931 ...
+%!        22.968 18.590 16.567 15.944 21.637 14.492 17.965 18.851 22.891 ...
+%!        22.028 16.884 17.252 18.325 25.435 19.141 21.238 22.196 18.038 ...
+%!        22.628 31.163 26.053 24.419 32.145 28.966 30.207 29.142 33.212 ...
+%!        25.694 ]';
+%! X = [1 1 1 1 1 1 1 1 2 2 2 2 2 3 3 3 3 3 3 3 3 4 4 4 4 4 4 4 5 5 5 5 5 5 5 5 5]';
+%!
+%! [TAB,STATS] = fitlm (X,y,"linear","CategoricalVars",1,"display","on");
+
+%!demo
+%! popcorn = [5.5, 4.5, 3.5; 5.5, 4.5, 4.0; 6.0, 4.0, 3.0; ...
+%!            6.5, 5.0, 4.0; 7.0, 5.5, 5.0; 7.0, 5.0, 4.5];
+%! brands = {'Gourmet', 'National', 'Generic'; ...
+%!           'Gourmet', 'National', 'Generic'; ...
+%!           'Gourmet', 'National', 'Generic'; ...
+%!           'Gourmet', 'National', 'Generic'; ...
+%!           'Gourmet', 'National', 'Generic'; ...
+%!           'Gourmet', 'National', 'Generic'};
+%! popper = {'oil', 'oil', 'oil'; 'oil', 'oil', 'oil'; 'oil', 'oil', 'oil'; ...
+%!           'air', 'air', 'air'; 'air', 'air', 'air'; 'air', 'air', 'air'};
+%!
+%! [TAB, STATS] = fitlm ({brands(:),popper(:)},popcorn(:),"interactions",...
+%!                          "CategoricalVars",[1,2],"display","on");
+
+%!test
+%! y =  [ 8.706 10.362 11.552  6.941 10.983 10.092  6.421 14.943 15.931 ...
+%!        22.968 18.590 16.567 15.944 21.637 14.492 17.965 18.851 22.891 ...
+%!        22.028 16.884 17.252 18.325 25.435 19.141 21.238 22.196 18.038 ...
+%!        22.628 31.163 26.053 24.419 32.145 28.966 30.207 29.142 33.212 ...
+%!        25.694 ]';
+%! X = [1 1 1 1 1 1 1 1 2 2 2 2 2 3 3 3 3 3 3 3 3 4 4 4 4 4 4 4 5 5 5 5 5 5 5 5 5]';
+%! [TAB,STATS] = fitlm (X,y,"continuous",[],"display","off");
+%! [TAB,STATS] = fitlm (X,y,"CategoricalVars",1,"display","off");
+%! [TAB,STATS] = fitlm (X,y,"constant","categorical",1,"display","off");
+%! [TAB,STATS] = fitlm (X,y,"linear","categorical",1,"display","off");
+%! [TAB,STATS] = fitlm (X,y,[0,0;1,0],"categorical",1,"display","off");
+%! assert (TAB{2,2}, 10, 1e-04);
+%! assert (TAB{3,2}, 7.99999999999999, 1e-09);
+%! assert (TAB{4,2}, 8.99999999999999, 1e-09);
+%! assert (TAB{5,2}, 11.0001428571429, 1e-09);
+%! assert (TAB{6,2}, 19.0001111111111, 1e-09);
+%! assert (TAB{2,3}, 1.01775379540949, 1e-09);
+%! assert (TAB{3,3}, 1.64107868458008, 1e-09);
+%! assert (TAB{4,3}, 1.43932122062479, 1e-09);
+%! assert (TAB{5,3}, 1.48983900477565, 1e-09);
+%! assert (TAB{6,3}, 1.3987687997822, 1e-09);
+%! assert (TAB{2,6}, 9.82555903510687, 1e-09);
+%! assert (TAB{3,6}, 4.87484242844031, 1e-09);
+%! assert (TAB{4,6}, 6.25294748040552, 1e-09);
+%! assert (TAB{5,6}, 7.38344399756088, 1e-09);
+%! assert (TAB{6,6}, 13.5834536158296, 1e-09);
+%! assert (TAB{3,7}, 2.85812420217862e-05, 1e-12);
+%! assert (TAB{4,7}, 5.22936741204002e-07, 1e-06);
+%! assert (TAB{5,7}, 2.12794763209106e-08, 1e-07);
+%! assert (TAB{6,7}, 7.82091664406755e-15, 1e-08);
+
+%!test
+%! popcorn = [5.5, 4.5, 3.5; 5.5, 4.5, 4.0; 6.0, 4.0, 3.0; ...
+%!            6.5, 5.0, 4.0; 7.0, 5.5, 5.0; 7.0, 5.0, 4.5];
+%! brands = bsxfun (@times, ones(6,1), [1,2,3]);
+%! popper = bsxfun (@times, [1;1;1;2;2;2], ones(1,3));
+%!
+%! [TAB, STATS] = fitlm ({brands(:),popper(:)},popcorn(:),"interactions",...
+%!                          "categoricalvars",[1,2],"display","off");
+%! assert (TAB{2,2}, 5.66666666666667, 1e-09);
+%! assert (TAB{3,2}, -1.33333333333333, 1e-09);
+%! assert (TAB{4,2}, -2.16666666666667, 1e-09);
+%! assert (TAB{5,2}, 1.16666666666667, 1e-09);
+%! assert (TAB{6,2}, -0.333333333333334, 1e-09);
+%! assert (TAB{7,2}, -0.166666666666667, 1e-09);
+%! assert (TAB{2,3}, 0.215165741455965, 1e-09);
+%! assert (TAB{3,3}, 0.304290309725089, 1e-09);
+%! assert (TAB{4,3}, 0.304290309725089, 1e-09);
+%! assert (TAB{5,3}, 0.304290309725089, 1e-09);
+%! assert (TAB{6,3}, 0.43033148291193, 1e-09);
+%! assert (TAB{7,3}, 0.43033148291193, 1e-09);
+%! assert (TAB{2,6}, 26.3362867542108, 1e-09);
+%! assert (TAB{3,6}, -4.38178046004138, 1e-09);
+%! assert (TAB{4,6}, -7.12039324756724, 1e-09);
+%! assert (TAB{5,6}, 3.83405790253621, 1e-09);
+%! assert (TAB{6,6}, -0.774596669241495, 1e-09);
+%! assert (TAB{7,6}, -0.387298334620748, 1e-09);
+%! assert (TAB{2,7}, 5.49841502258254e-12, 1e-09);
+%! assert (TAB{3,7}, 0.000893505495903642, 1e-09);
+%! assert (TAB{4,7}, 1.21291454302428e-05, 1e-09);
+%! assert (TAB{5,7}, 0.00237798044119407, 1e-09);
+%! assert (TAB{6,7}, 0.453570536021938, 1e-09);
+%! assert (TAB{7,7}, 0.705316781644046, 1e-09);
+%! ## Test with string ids for categorical variables
+%! brands = {'Gourmet', 'National', 'Generic'; ...
+%!           'Gourmet', 'National', 'Generic'; ...
+%!           'Gourmet', 'National', 'Generic'; ...
+%!           'Gourmet', 'National', 'Generic'; ...
+%!           'Gourmet', 'National', 'Generic'; ...
+%!           'Gourmet', 'National', 'Generic'};
+%! popper = {'oil', 'oil', 'oil'; 'oil', 'oil', 'oil'; 'oil', 'oil', 'oil'; ...
+%!           'air', 'air', 'air'; 'air', 'air', 'air'; 'air', 'air', 'air'};
+%! [TAB, STATS] = fitlm ({brands(:),popper(:)},popcorn(:),"interactions",...
+%!                          "categoricalvars",[1,2],"display","off");
+
+%!test 
+%! load carsmall
+%! X = [Weight,Horsepower,Acceleration];
+%! [TAB, STATS] = fitlm (X, MPG,"constant","display","off");
+%! [TAB, STATS] = fitlm (X, MPG,"linear","display","off");
+%! assert (TAB{2,2}, 47.9767628118615, 1e-09);
+%! assert (TAB{3,2}, -0.00654155878851796, 1e-09);
+%! assert (TAB{4,2}, -0.0429433065881864, 1e-09);
+%! assert (TAB{5,2}, -0.0115826516894871, 1e-09);
+%! assert (TAB{2,3}, 3.87851641748551, 1e-09);
+%! assert (TAB{3,3}, 0.00112741016370336, 1e-09);
+%! assert (TAB{4,3}, 0.0243130608813806, 1e-09);
+%! assert (TAB{5,3}, 0.193325043113178, 1e-09);
+%! assert (TAB{2,6}, 12.369874881944, 1e-09);
+%! assert (TAB{3,6}, -5.80228828790225, 1e-09);
+%! assert (TAB{4,6}, -1.76626492228599, 1e-09);
+%! assert (TAB{5,6}, -0.0599128364487485, 1e-09);
+%! assert (TAB{2,7}, 4.89570341688996e-21, 1e-09);
+%! assert (TAB{3,7}, 9.87424814144e-08, 1e-09);
+%! assert (TAB{4,7}, 0.0807803098213114, 1e-09);
+%! assert (TAB{5,7}, 0.952359384151778, 1e-09);

--- a/inst/fitlm.m
+++ b/inst/fitlm.m
@@ -121,9 +121,9 @@
 ## corresponds to the column number in the relevant contrast matrix for that
 ## factor. The @var{stats} structure can be used as input for @qcode{multcompare}.
 ## Note that if the model contains a continuous variable and you wish to use
-## the @var{STATS} output as input to @qcode{multcompare}, it needs to be
-## refit with "contrast" parameter set to sum-to-zero contrast coding scheme,
-## e.g."simple".
+## the @var{STATS} output as input to @qcode{multcompare}, then the model needs
+## to be refit with the "contrast" parameter set to a sum-to-zero contrast
+## coding scheme, e.g."simple".
 ##
 ## @seealso{anovan, multcompare}
 ## @end deftypefn

--- a/inst/multcompare.m
+++ b/inst/multcompare.m
@@ -149,7 +149,7 @@
 ## containing the graph.  @var{GNAMES} is a cell array with one row for each
 ## group, containing the names of the groups.
 ##
-## @seealso{anova1, anova2, anovan, kruskalwallis, friedman}
+## @seealso{anova1, anova2, anovan, kruskalwallis, friedman, fitlm}
 ## @end deftypefn
 
 function [C, M, H, GNAMES] = multcompare (STATS, varargin)
@@ -343,7 +343,7 @@ function [C, M, H, GNAMES] = multcompare (STATS, varargin)
         ## Create character array of group names corresponding to each row of m
         GNAMES = cellstr (num2str ([1:Ng]'));
 
-      case "anovan"
+      case {"anovan","fitlm"}
 
         ## Our calculations treat all effects as fixed
         if (ismember (STATS.random, DIM))
@@ -355,6 +355,12 @@ function [C, M, H, GNAMES] = multcompare (STATS, varargin)
         if (any (STATS.nlevels(DIM) < 2))
           error (strcat (["multcompare: DIM must specify only categorical"], ...
                          [" factors with 2 or more degrees of freedom."]));
+        endif
+
+        ## Check that continuous variables were centered
+        if (! STATS.center_continuous)
+          error (strcat (["use a STATS structure from a model refit with"], ...
+                         [" sum-to-zero contrasts coding, e.g. ""simple"""]))
         endif
 
         ## Calculate estimated marginal means and their standard errors
@@ -1148,3 +1154,35 @@ endfunction
 %! assert (C(3,6), 0.649836502233148, 1e-09);
 %! set (0, "DefaultFigureVisible", visibility_setting);
 
+%!test
+%! set (0, "DefaultFigureVisible", "off");
+%! ## Test for fitlm - same comparisons as for first anovan example
+%! y =  [ 8.706 10.362 11.552  6.941 10.983 10.092  6.421 14.943 15.931 ...
+%!        22.968 18.590 16.567 15.944 21.637 14.492 17.965 18.851 22.891 ...
+%!        22.028 16.884 17.252 18.325 25.435 19.141 21.238 22.196 18.038 ...
+%!        22.628 31.163 26.053 24.419 32.145 28.966 30.207 29.142 33.212 ...
+%!        25.694 ]';
+%! X = [1 1 1 1 1 1 1 1 2 2 2 2 2 3 3 3 3 3 3 3 3 4 4 4 4 4 4 4 5 5 5 5 5 5 5 5 5]';
+%! [TAB,STATS] = fitlm (X,y,"linear","categorical",1,"display","off");
+%! [C, M] = multcompare(STATS, "ctype", "lsd");
+%! assert (C(1,6), 2.85812420217898e-05, 1e-09);
+%! assert (C(2,6), 5.22936741204085e-07, 1e-09);
+%! assert (C(3,6), 2.12794763209146e-08, 1e-09);
+%! assert (C(4,6), 7.82091664406946e-15, 1e-09);
+%! assert (C(5,6), 0.546591417210693, 1e-09);
+%! assert (C(6,6), 0.0845897945254446, 1e-09);
+%! assert (C(7,6), 9.47436557975328e-08, 1e-09);
+%! assert (C(8,6), 0.188873478781067, 1e-09);
+%! assert (C(9,6), 4.08974010364197e-08, 1e-09);
+%! assert (C(10,6), 4.44427348175241e-06, 1e-09);
+%! assert (M(1,1), 10, 1e-09);
+%! assert (M(2,1), 18, 1e-09);
+%! assert (M(3,1), 19, 1e-09);
+%! assert (M(4,1), 21.0001428571429, 1e-09);
+%! assert (M(5,1), 29.0001111111111, 1e-09);
+%! assert (M(1,2), 1.0177537954095, 1e-09);
+%! assert (M(2,2), 1.28736803631001, 1e-09);
+%! assert (M(3,2), 1.0177537954095, 1e-09);
+%! assert (M(4,2), 1.0880245732889, 1e-09);
+%! assert (M(5,2), 0.959547480416536, 1e-09);
+%! set (0, "DefaultFigureVisible", visibility_setting);


### PR DESCRIPTION
`anovan`:
- added support for missing data in nan (by ommission)
- minor bug fix to prevent warning under some circumstances when creating STATS.coeffnames
- fixed bug that occurred when trying to run model 'interaction' when there is only one factor in GROUP
- changed it so that continuous variables are centered for all contrasts except "treatment"

`fitlm`:
- new function for fitting linear models including demos and BISTs

`multcompare`
- added support for `fitlm`