### PR TITLE
z_test_2.m: Fix the state of the rng for the tests to avoid random fails.

### DIFF
--- a/inst/z_test_2.m
+++ b/inst/z_test_2.m
@@ -87,6 +87,11 @@ function [pval, z] = z_test_2 (x, y, v_x, v_y, alt)
 
 endfunction
 
+%!shared restore_nstate
+%! old_nstate = randn ("state");
+%! restore_nstate = onCleanup (@() randn ("state", old_nstate));
+%! randn ("state", 42); # initialize generator to make behavior reproducible
+
 %!test
 %! ## Two-sided (also the default option)
 %! x = randn (100, 1); v_x = 2; x = v_x * x;


### PR DESCRIPTION
See also: https://octave.discourse.group/t/3322

There are multiple tests in that file that use randomly generated input. So, I used a shared block to set a fixed state at the beginning of all of them instead of for each single one.