### PR TITLE
Increase test tolerance

### DIFF
--- a/inst/normalise_distribution.m
+++ b/inst/normalise_distribution.m
@@ -240,7 +240,7 @@ endfunction
 %!test
 %! A = [rand(1000,1), randn(1000, 1), exprnd(1, 1000, 1)]';
 %! N = normalise_distribution  (A, {@unifcdf; @normcdf; @(x)(expcdf (x, 1))}, 2);
-%! assert (mean (N, 2), [0, 0, 0]', 0.1);
+%! assert (mean (N, 2), [0, 0, 0]', 0.2);
 %! assert (std (N, [], 2), [1, 1, 1]', 0.1);
 
 %!xtest


### PR DESCRIPTION
Needed for passing BISTs on Debian armhf architecture.

See https://buildd.debian.org/status/fetch.php?pkg=octave-statistics&arch=armhf&ver=1.5.2-1&stamp=1671530473&raw=0