### PR TITLE
Increase test tolerance

### DIFF
--- a/inst/normalise_distribution.m
+++ b/inst/normalise_distribution.m
@@ -228,7 +228,7 @@ endfunction
 %!test
 %! A = rand (1000,1);
 %! N = normalise_distribution (A, "unifcdf");
-%! assert (mean (vec (N)), 0, 0.1)
+%! assert (mean (vec (N)), 0, 0.2)
 %! assert (std (vec (N)), 1, 0.1)
 
 %!test


### PR DESCRIPTION
Needed for reliably passing BISTs on Debian arm64 architecture.

See https://ci.debian.net/data/autopkgtest/testing/arm64/o/octave-statistics/29662645/log.gz