### PR TITLE
mean / median / fillmissing - rework mean, streamline median and fillmissing to fix bug #54567

### DIFF
--- a/inst/fillmissing.m
+++ b/inst/fillmissing.m
@@ -1396,10 +1396,10 @@ function med = columnwise_median (x)
   ## of what's left.  returns NaN if no values.
   ## uses only built-in fns to avoid 3x 'median' slowdown
 
-  sz_x = size (x);
+  szx = size (x);
 
   if (isempty (x))
-    med = NaN ([1, sz_x(2:end)]);
+    med = NaN ([1, szx(2:end)]);
 
   elseif (isvector (x))
     x = x(! isnan (x));
@@ -1419,27 +1419,27 @@ function med = columnwise_median (x)
   else
     x = sort (x, 1); # NaNs sent to bottom
     n = sum (! isnan (x), 1);
-    odd = logical (mod (n, 2)); # 0 even or zero, 1 odd
-    even = !odd & (n != 0);
+    m_idx_odd = logical (mod (n, 2)); # 0 even or zero, 1 odd
+    m_idx_even = !m_idx_odd & (n != 0);
+    k = floor ((n + 1) ./ 2);
 
-    if (ismatrix (x))
-      med = NaN ([1, sz_x(2)]);
-      med_idx_odd = sub2ind (sz_x, (n(odd)+1)/2, (1 : sz_x(2))(odd));
-      med_idx_even = sub2ind (sz_x, [n(even)/2; n(even)/2 + 1], ...
-                                  (1 : sz_x(2))(even)([1 1], :));
+    med = NaN ([1, szx(2:end)]);
 
-    else #nD arrays
-      sz_x_flat = [sz_x(1), prod(sz_x(2:end))];
-      med = NaN ([1, sz_x(2:end)]);
-      med_idx_odd = sub2ind (sz_x_flat, ...
-                      ((n(odd)+1)/2)(:)', (1 : sz_x_flat(2))(odd)(:)');
-      med_idx_even = sub2ind (sz_x_flat, ...
-                                [(n(even)/2)(:)'; (n(even)/2 + 1)(:)'], ...
-                                   (1 : sz_x_flat(2))(even)([1 1], :));
+    if (! ismatrix (x))
+      szx = [szx(1), prod(szx(2:end))];
     endif
 
-    med(odd) = x(med_idx_odd);
-    med(even) = sum (x(med_idx_even), 1) / 2;
+    if any (m_idx_odd(:))
+      x_idx_odd = sub2ind (szx, k(m_idx_odd)(:), find(m_idx_odd)(:));;
+      med(m_idx_odd) = x(x_idx_odd);
+    endif
+
+    if any (m_idx_even(:))
+      k_even = k(m_idx_even)(:);
+      x_idx_even = sub2ind (szx, [k_even, k_even+1], ...
+                                (find (m_idx_even))(:,[1 1]));;
+      med(m_idx_even) = sum (x(x_idx_even), 2) / 2;
+    endif
   endif
 
 endfunction

--- a/inst/shadow9/mean.m
+++ b/inst/shadow9/mean.m
@@ -369,7 +369,7 @@ endfunction
 %! assert (mean (in, "native"), uint8 (out_u8));
 %! assert (class (mean (in, "native")), "uint8");
 
-%!test <54567> ## internal sum exceeding intmax
+%!test ## internal sum exceeding intmax
 %! in = uint8 ([3 141 141 255]);
 %! out = 135;
 %! assert (mean (in, "default"), mean (in));
@@ -378,7 +378,7 @@ endfunction
 %! assert (mean (in, "native"), uint8 (out));
 %! assert (class (mean (in, "native")), "uint8");
 
-%!test <54567>
+%!test ## fractional answer with interal sum exceeding intmax
 %! in = uint8 ([1 141 141 255]);
 %! out = 134.5;
 %! out_u8 = 135;
@@ -402,6 +402,18 @@ endfunction
 %! assert (mean (in, "default"), mean (in), eps);
 %! assert (mean (in, "default"), out, eps);
 %! assert (mean (in, "double"), out, eps);
+
+## int64 loss of precision with double conversion
+%!test <54567>
+%! in = [(intmin('int64')+5)  (intmax('int64'))-5];
+%! out_double_noerror = double (in(1)+in(2)) / 2;
+%! out_int = (in(1)+in(2)) / 2;
+%! assert (mean (in, "native"), out_int);
+%! assert (class(mean (in, "native")), "int64");
+%! assert (mean (double(in)), out_double_noerror );
+%! assert (mean (in), out_double_noerror );
+%! assert (mean (in, "default"), out_double_noerror );
+%! assert (mean (in, "double"), out_double_noerror );
 
 ## Test input and optional arguments "all", DIM, "omitnan")
 %!test

--- a/inst/shadow9/mean.m
+++ b/inst/shadow9/mean.m
@@ -402,16 +402,18 @@ endfunction
 %! assert (mean (in, "double"), out, eps);
 
 ## int64 loss of precision with double conversion
-%!test <54567>
-%! in = [(intmin('int64')+5)  (intmax('int64'))-5];
-%! out_double_noerror = -0.5;
-%! out_int = -1;
-%! assert (mean (in, "native"), out_int);
-%! assert (class(mean (in, "native")), "int64");
-%! assert (mean (double(in)), 0 );
-%! assert (mean (in), out_double_noerror );
-%! assert (mean (in, "default"), out_double_noerror );
-%! assert (mean (in, "double"), out_double_noerror );
+%!assert <54567> (mean (
+%!           [(intmin('int64')+5), (intmax('int64'))-5], "native"), int64(-1));
+%!assert (class(mean (...
+%!            [(intmin('int64')+5), (intmax('int64'))-5], "native")), "int64");
+%!assert (mean (...
+%!            double([(intmin('int64')+5), (intmax('int64'))-5])), double(0) );
+%!assert <54567> (mean (...
+%!            [(intmin('int64')+5), (intmax('int64'))-5]), double(-0.5) );
+%!assert <54567> (mean (...
+%!      [(intmin('int64')+5), (intmax('int64'))-5], "default"), double(-0.5) );
+%!assert <54567> (mean (...
+%!       [(intmin('int64')+5), (intmax('int64'))-5], "double"), double(-0.5) );
 
 ## Test input and optional arguments "all", DIM, "omitnan")
 %!test

--- a/inst/shadow9/mean.m
+++ b/inst/shadow9/mean.m
@@ -406,11 +406,11 @@ endfunction
 ## int64 loss of precision with double conversion
 %!test <54567>
 %! in = [(intmin('int64')+5)  (intmax('int64'))-5];
-%! out_double_noerror = double (in(1)+in(2)) / 2;
-%! out_int = (in(1)+in(2)) / 2;
+%! out_double_noerror = -0.5;
+%! out_int = -1;
 %! assert (mean (in, "native"), out_int);
 %! assert (class(mean (in, "native")), "int64");
-%! assert (mean (double(in)), out_double_noerror );
+%! assert (mean (double(in)), 0 );
 %! assert (mean (in), out_double_noerror );
 %! assert (mean (in, "default"), out_double_noerror );
 %! assert (mean (in, "double"), out_double_noerror );

--- a/inst/shadow9/mean.m
+++ b/inst/shadow9/mean.m
@@ -515,6 +515,11 @@ endfunction
 %! m(2,1,1,3) = 15.52301255230125;
 %! assert (mean (x, [3 2], "omitnan"), m, 4e-14);
 
+## Test input case insensitivity
+%!assert (mean ([1 2 3], "aLL"), 2);
+%!assert (mean ([1 2 3], "OmitNan"), 2);
+%!assert (mean ([1 2 3], "DOUBle"), 2);
+
 ## Test input validation
 %!error <Invalid call to mean.  Correct usage is> mean ()
 %!error <Invalid call to mean.  Correct usage is> mean (1, 2, 3)

--- a/inst/shadow9/median.m
+++ b/inst/shadow9/median.m
@@ -298,7 +298,7 @@ function m = median (x, varargin)
       num_dim = prod (szx(dim));
       szx(dim) = [];
       szx = [ones(1, length(dim)), szx];
-      szx(1) = prod (num_dim);
+      szx(1) = num_dim;
       x = reshape (x, szx);
       dim = 1;
     endif

--- a/inst/shadow9/median.m
+++ b/inst/shadow9/median.m
@@ -241,9 +241,8 @@ function m = median (x, varargin)
       dim = 2;
       sz_out = [1, 1];
 
-    elseif (isempty (x) && isequal (szx, [0, 0]))
+    elseif (ndx == 2 && szx == [0, 0])
       ## Special case []: Do not apply sz_out(dim)=1 change
-      ##   (check isempty first to reduce overhead on non-emptys)
       dim = 1;
       sz_out = [1, 1];
 

--- a/inst/shadow9/median.m
+++ b/inst/shadow9/median.m
@@ -389,7 +389,7 @@ function m = median (x, varargin)
         endif
 
       else
-        ## Nonvector, all operations permuted to be along dim 1
+        ## Nonvector, all operations were permuted to be along dim 1
         n = szx(1);
         k = floor ((n + 1) / 2);
 
@@ -416,7 +416,7 @@ function m = median (x, varargin)
             m(nanfree) = (x(k, nanfree) + x(k+1, nanfree)) / 2;
           endif
         else
-          ## Use flattened index to simplify n-D operations
+          ## Odd. Use flattened index to simplify n-D operations
           m(nanfree) = x(k, nanfree);
         endif
       endif

--- a/inst/shadow9/median.m
+++ b/inst/shadow9/median.m
@@ -23,7 +23,6 @@
 ## @deftypefnx {statistics} @var{m} = median (@var{x}, @var{vecdim})
 ## @deftypefnx {statistics} @var{m} = median (@dots{}, @var{outtype})
 ## @deftypefnx {statistics} @var{m} = median (@dots{}, @var{nanflag})
-##
 ## Compute the median value of the elements of @var{x}.
 ##
 ## When the elements of @var{x} are sorted, say
@@ -101,6 +100,8 @@
 ## @end deftypefn
 
 function m = median (x, varargin)
+
+### TODO: check relative speed of using nth_element
 
   if (nargin < 1 || nargin > 4)
     print_usage ();
@@ -604,8 +605,12 @@ endfunction
 %!assert (median (uint8 ([1, 3])), uint8 (2))
 %!assert (median (uint8 ([])), uint8 (NaN))
 %!assert (median (uint8 ([NaN 10])), uint8 (5))
+%!assert <54567> (median (uint8 ([253, 255])), uint8 (254))
+%!assert <54567> (median (uint8 ([253, 254])), uint8 (254))
 %!assert (median (int8 ([1, 3, 4])), int8 (3))
 %!assert (median (int8 ([])), int8 (NaN))
+%!assert <54567> (median (int8 ([127, 126, 125, 124; 1 3 5 9])), int8 ([64 65 65 67]))
+%!assert <54567> (median (int8 ([127, 126, 125, 124; 1 3 5 9]), 2), int8 ([126; 4]))
 %!assert (median (single ([1, 3, 4])), single (3))
 %!assert (median (single ([1, 3, NaN])), single (NaN))
 

--- a/inst/shadow9/median.m
+++ b/inst/shadow9/median.m
@@ -348,14 +348,16 @@ function m = median (x, varargin)
       endif
 
       ## Grab kth value, k possibly different for each column
-      x_idx_odd = sub2ind (szx, (k(m_idx_odd))(:).', ...
-                             (1 : szx(2))(m_idx_odd)(:).');
-      x_idx_even = sub2ind (szx, ...
-                           [(k(m_idx_even))(:).'; (k(m_idx_even) + 1)(:).'], ...
-                             (1 : szx(2))(m_idx_even)([1 1], :));
-
-      m(m_idx_odd) = x(x_idx_odd);
-      m(m_idx_even) = sum (x(x_idx_even), 1) / 2;
+      if (any (m_idx_odd(:)))
+        x_idx_odd = sub2ind (szx, k(m_idx_odd), find (m_idx_odd));
+        m(m_idx_odd) = x(x_idx_odd);
+      endif
+      if (any (m_idx_even(:)))
+        k_even = k(m_idx_even)(:);
+        x_idx_even = sub2ind (szx, [k_even, k_even+1], ...
+                                (find (m_idx_even))(:,[1 1]));
+        m(m_idx_even) = sum (x(x_idx_even), 2) / 2;
+      endif
     endif
 
   else

--- a/inst/shadow9/median.m
+++ b/inst/shadow9/median.m
@@ -642,10 +642,7 @@ endfunction
 %!assert (median (single ([1, 3, 4])), single (3))
 %!assert (median (single ([1, 3, NaN])), single (NaN))
 
-## Test int overflow when getting mean of middle values
-##    all fixed by min+(max-min)/2 assuming proper rounding.  All but int64s
-##    could be fixed by processing as doubles, but int64s lose precision for
-##    very close large values.
+## Test same sign int overflow when getting mean of even number of values
 %!assert <54567> (median (uint8 ([253, 255])), uint8 (254))
 %!assert <54567> (median (uint8 ([253, 254])), uint8 (254))
 %!assert <54567> (median (int8 ([127, 126, 125, 124; 1 3 5 9])), ...
@@ -663,8 +660,7 @@ endfunction
 %!                 uint64 ([intmax("uint64"), intmax("uint64")-2; 1 2]), 2), ...
 %!                 uint64([intmax("uint64") - 1; 2]))
 
-##    Neg sign breaks min+(max-min)/2. wolud work fine if just (min+max)/2
-##    again, applies to all ints, but int64s only ones can't be fixed by doubles
+## Test opposite sign int overflow when getting mean of even number of values
 %!assert <54567> (median (...
 %! [intmin('int8') intmin('int8')+5 intmax('int8')-5 intmax('int8')]), ...
 %! int8(-1))
@@ -678,11 +674,15 @@ endfunction
 %! intmin('int64') intmin('int64')+5 intmax('int64')-5 intmax('int64')], 2), ...
 %! int64([3;-1]))
 
-## Test int accuracy loss doing mean of int64/uint64 values as double
-##    as doubles, using standard (min+max)/2 with proper rounding. rounding
-##    becomes problematic if using (min/2 + max/2) to try to solve both, and
-##    runs into double precision issues if handling that way.
-
+## Test int accuracy loss doing mean of close int64/uint64 values as double
+%!assert <54567> (median ([intmax("uint64"), intmax("uint64")-2]), ...
+%!  intmax("uint64")-1)
+%!assert <54567> (median ([intmax("uint64"), intmax("uint64")-2], "default"), ...
+%!  double(intmax("uint64")-1))
+%!assert <54567> (median ([intmax("uint64"), intmax("uint64")-2], "double"), ...
+%!  double(intmax("uint64")-1))
+%!assert <54567> (median ([intmax("uint64"), intmax("uint64")-2], "native"), ...
+%!  intmax("uint64")-1)
 
 ## Test input case insensitivity
 %!assert (median ([1 2 3], "aLL"), 2);


### PR DESCRIPTION
* inst/shadow9/mean - Rework function to streamline input processing and reduce called function overhead. Implement reshaping to dim1 for streamlined operations.  Add BISTs to ensure compatible class handling.  
* inst/shadow9/median - Additional called function streamlining.  Simplify code paths when no NaN values are present. Change handling of ints to avoid summation overflow and/or limits of double precision processing for large (u)int64 values.
* inst/fillmissing - Streamline columnwise_median subfunction following improvements to median.

Note: still looking at possibility of fixing bug #54567 (int64 overflow and precision loss) in mean before opening patch to push group to core.   