### PR TITLE
Yet another increase of test tolerance

### DIFF
--- a/inst/crossval.m
+++ b/inst/crossval.m
@@ -169,8 +169,8 @@ endfunction
 %! ## to slightly reduce cross-validation mean square error
 %! results6 = crossval (f, X, y, 'KFold', 5, 'stratify', grp2idx(species));
 %!
-%! assert (results0, results1, 2e-16);
-%! assert (results2, results3, 4e-17);
+%! assert (results0, results1, 2e-15);
+%! assert (results2, results3, 5e-17);
 %! assert (size(results4), [1 numel(y)]);
 %! assert (mean(results4), 0.1018, 1e-4);
 %! assert (size(results5), [mcreps 1]);


### PR DESCRIPTION
Needed for reliably passing BISTs on Debian ppc64el. See https://buildd.debian.org/status/fetch.php?pkg=octave-statistics&arch=ppc64el&ver=1.5.4-3&stamp=1682356882&raw=0