### PR TITLE
Increase tolerance of failing BIST for normfit

### DIFF
--- a/inst/dist_fit/normfit.m
+++ b/inst/dist_fit/normfit.m
@@ -430,7 +430,7 @@ endfunction
 %! idx = find (lightbulb(:,2) == 0);
 %! censoring = lightbulb(idx,3) == 1;
 %! [muHat, sigmaHat] = normfit (lightbulb(idx,1), [], censoring);
-%! assert (muHat, 9496.595867378575, 1e-12);
+%! assert (muHat, 9496.59586737857, 1e-11);
 %! assert (sigmaHat, 3064.021012796456, 1e-12);
 %!test
 %! x = normrnd (3, 5, [1000, 1]);


### PR DESCRIPTION
Testing of the normfit function (version 1.6.0 of the statistics package) is failing on my Debian amd64 system, with the error message below. This commit fixes the problem.

```
octave:1> pkg
octave:2> test normfit
***** test
 load lightbulb
 idx = find (lightbulb(:,2) == 0);
 censoring = lightbulb(idx,3) == 1;
 [muHat, sigmaHat] = normfit (lightbulb(idx,1), [], censoring);
 assert (muHat, 9496.595867378575, 1e-12);
 assert (sigmaHat, 3064.021012796456, 1e-12);
!!!!! test failed
ASSERT errors for:  assert (muHat,9496.595867378575,1e-12)

  Location  |  Observed  |  Expected  |  Reason
     ()       9496.5959    9496.5959     Abs err 1.819e-12 exceeds tol 1e-12 by 8e-13
```