### PR TITLE
update ztest2 for deprecated stdnormal function

### DIFF
--- a/inst/ztest2.m
+++ b/inst/ztest2.m
@@ -120,7 +120,7 @@ function [h, pval, zvalue] = ztest2 (x1, n1, x2, n2, varargin)
 
   zvalue  = (p1 - p2) ./ sqrt (pc .* (1 - pc) .* (1 ./ n1 + 1 ./ n2));
 
-  cdf = stdnormal_cdf (zvalue);
+  cdf = normcdf (zvalue);
 
   if (strcmpi (tail, "both"))
     pval = 2 * min (cdf, 1 - cdf);


### PR DESCRIPTION
Using Octave 8.3.0, after installing the package statistics 1.6.0 from forge on my machine, attempting to call ztest2 results in the following error:
```
octave:9> [h, pval, z] = ztest2(27, 100, 19, 100)
error: 'stdnormal_cdf' undefined near line 123, column 9

The 'stdnormal_cdf' function belongs to the statistics package from
Octave Forge but has not yet been implemented.

Please read <https://www.octave.org/missing.html> to learn how you can
contribute missing functionality.
error: called from
    ztest2 at line 123 column 7
```

Making the change in this pull request and reinstalling from a locally created tarball causes the function to work as expected:
```
octave:13> [h, pval, z] = ztest2(27, 100, 19, 100)
h = 0
pval = 0.1789
z = 1.3442
```

There are likely other functions with similar issues.