### PR TITLE
chi2gof.m: Add newline after `@tex` to avoid issues with newer makeinfo.

### DIFF
--- a/inst/chi2gof.m
+++ b/inst/chi2gof.m
@@ -27,7 +27,8 @@
 ## continuous distributions.  The test is performed by grouping the data into
 ## bins, calculating the observed and expected counts for those bins, and
 ## computing the chi-square test statistic
-## @tex $$ \chi ^ 2 = \sum_{i=1}^N \left (O_i - E_i \right) ^ 2 / E_i $$
+## @tex
+## $$ \chi ^ 2 = \sum_{i=1}^N \left (O_i - E_i \right) ^ 2 / E_i $$
 ## @end tex
 ## @ifnottex
 ## SUM((O-E).^2./E),


### PR DESCRIPTION
Newer versions of `makeinfo` seem to be unable to process texinfo when there is text in the same line as the @tex formatter.
Add a newline after @tex to avoid that issue.

Fwiw:
```
$ makeinfo --version
texi2any (GNU texinfo) 7.1
```
```
octave:2> help chi2gof
C:\msys64\tmp\octave-help-xG5EZL:141: fehlplatzierte {
C:\msys64\tmp\octave-help-xG5EZL:141: fehlplatzierte }
C:\msys64\tmp\octave-help-xG5EZL:141: fehlplatzierte {
C:\msys64\tmp\octave-help-xG5EZL:141: fehlplatzierte }
warning: help: Texinfo formatting filter exited abnormally; raw Texinfo source of help text follows...
```
