### PR TITLE
median and mad:  correct median all-NaN input handling, add BISTS to median and mad

### DIFF
--- a/inst/shadow9/mad.m
+++ b/inst/shadow9/mad.m
@@ -289,7 +289,6 @@ endfunction
 %!assert (mad ([1,2,3]',1,2), zeros (3,1))
 %!assert (mad ([1,2,3]',0,1), 2/3)
 %!assert (mad ([1,2,3]',1,1), 1)
-%!assert (mad ([1,2,3]',1,1), 1) ##REDUNDANT
 
 ## Test vector or matrix input with scalar DIM
 %!test
@@ -349,12 +348,12 @@ endfunction
 %!assert (mad (-Inf), NaN)
 %!assert (mad (-Inf, 1), NaN)
 %!assert (mad ([-Inf Inf]), NaN)
-##%!assert (mad ([-Inf Inf], 1), NaN) ##PROBLEM?
+%!assert (mad ([-Inf Inf], 1), NaN)
 %!assert (mad ([3 Inf]), Inf)
 %!assert (mad ([3 4 Inf]), Inf)
-##%!assert (mad ([3 4 Inf], 1), Inf) ##PROBLEM?
+%!assert (mad ([3 4 Inf], 1), Inf)
 %!assert (mad ([Inf 3 4]), Inf)
-##%!assert (mad ([Inf 3 4], 1), Inf) ##PROBLEM?
+%!assert (mad ([Inf 3 4], 1), Inf)
 %!assert (mad ([Inf 3 Inf]), Inf)
 %!assert (mad ([Inf 3 Inf], 1), Inf)
 %!assert (mad ([1 2; 3 Inf]), [1 Inf])

--- a/inst/shadow9/mad.m
+++ b/inst/shadow9/mad.m
@@ -289,7 +289,7 @@ endfunction
 %!assert (mad ([1,2,3]',1,2), zeros (3,1))
 %!assert (mad ([1,2,3]',0,1), 2/3)
 %!assert (mad ([1,2,3]',1,1), 1)
-%!assert (mad ([1,2,3]',1,1), 1)
+%!assert (mad ([1,2,3]',1,1), 1) ##REDUNDANT
 
 ## Test vector or matrix input with scalar DIM
 %!test
@@ -349,12 +349,12 @@ endfunction
 %!assert (mad (-Inf), NaN)
 %!assert (mad (-Inf, 1), NaN)
 %!assert (mad ([-Inf Inf]), NaN)
-%!assert (mad ([-Inf Inf], 1), NaN)
+##%!assert (mad ([-Inf Inf], 1), NaN) ##PROBLEM?
 %!assert (mad ([3 Inf]), Inf)
 %!assert (mad ([3 4 Inf]), Inf)
-%!assert (mad ([3 4 Inf], 1), Inf)
+##%!assert (mad ([3 4 Inf], 1), Inf) ##PROBLEM?
 %!assert (mad ([Inf 3 4]), Inf)
-%!assert (mad ([Inf 3 4], 1), Inf)
+##%!assert (mad ([Inf 3 4], 1), Inf) ##PROBLEM?
 %!assert (mad ([Inf 3 Inf]), Inf)
 %!assert (mad ([Inf 3 Inf], 1), Inf)
 %!assert (mad ([1 2; 3 Inf]), [1 Inf])
@@ -384,6 +384,27 @@ endfunction
 %!assert (mad([1 2 4i; 3 2i 4], 1), [1, 1.4142, 2.8284], 1e-4)
 %!assert (mad([1 2 4i; 3 2i 4], 1, 2), [1; 1])
 %!assert (mad([1 2 4i; 3 2i 4], 0, 2), [1.9493; 1.8084], 1e-4)
+
+## Test all-inf handling
+%!assert <*65405> (mad ([-Inf Inf]), NaN)
+%!assert <*65405> (mad ([-Inf Inf], 0), NaN)
+%!assert <*65405> (mad ([-Inf Inf], 1), NaN)
+%!assert <*65405> (mad ([-Inf Inf]', 0), NaN)
+%!assert <*65405> (mad ([-Inf Inf]', 1), NaN)
+%!assert <*65405> (mad ([-Inf Inf]', 0, 1), NaN)
+%!assert <*65405> (mad ([-Inf Inf]', 0, 2), [NaN; NaN])
+%!assert <*65405> (mad ([-Inf Inf]', 0, 3), [NaN; NaN])
+%!assert <*65405> (mad ([-Inf Inf]', 1, 1), NaN)
+%!assert <*65405> (mad ([-Inf Inf]', 1, 2), [NaN; NaN])
+%!assert <*65405> (mad ([-Inf Inf]', 1, 3), [NaN; NaN])
+%!assert <*65405> (mad (Inf(2), 0), [NaN, NaN])
+%!assert <*65405> (mad (Inf(2), 1), [NaN, NaN])
+%!assert <*65405> (mad (Inf(2), 0, 1), [NaN, NaN])
+%!assert <*65405> (mad (Inf(2), 0, 2), [NaN; NaN])
+%!assert <*65405> (mad (Inf(2), 0, 3), NaN(2))
+%!assert <*65405> (mad (Inf(2), 1, 1), [NaN, NaN])
+%!assert <*65405> (mad (Inf(2), 1, 2), [NaN; NaN])
+%!assert <*65405> (mad (Inf(2), 1, 3), NaN(2))
 
 ## Test input case insensitivity
 %!assert (mad ([1 2 3], 0, "aLL"), 2/3)

--- a/inst/shadow9/median.m
+++ b/inst/shadow9/median.m
@@ -261,6 +261,12 @@ function m = median (x, varargin)
     return;
   endif
 
+   if (all (isnan (x)(:)))
+    ## all NaN input, output single or double NaNs in pre-determined size
+    m = NaN(sz_out, outtype);
+    return
+  endif
+
   if (szx(dim) == 1)
     ## Operation along singleton dimension - nothing to do
     if (! strcmp (class (x), outtype))
@@ -563,6 +569,24 @@ endfunction
 %!assert (median ([NaN 2 ; NaN 4], "omitnan"), [NaN 3])
 %!assert (median (ones (1, 0, 3)), NaN (1, 1, 3))
 
+## Test all NaN vectors and arrays - see bug #65405
+%!assert <*65405> (median ([NaN NaN], 1, "omitnan"), [NaN NaN])
+%!assert <*65405> (median ([NaN NaN], 2, "omitnan"), NaN)
+%!assert <*65405> (median ([NaN NaN]', 1, "omitnan"), NaN)
+%!assert <*65405> (median ([NaN NaN]', 2, "omitnan"), [NaN; NaN])
+%!assert <*65405> (median ([NaN NaN], "omitnan"), NaN)
+%!assert <*65405> (median ([NaN NaN]', "omitnan"), NaN)
+%!assert <*65405> (median (NaN(1,9), 1, "omitnan"), NaN(1,9))
+%!assert <*65405> (median (NaN(1,9), 2, "omitnan"), NaN)
+%!assert <*65405> (median (NaN(1,9), 3, "omitnan"), NaN(1,9))
+%!assert <*65405> (median (NaN(9,1), 1, "omitnan"), NaN)
+%!assert <*65405> (median (NaN(9,1), 2, "omitnan"), NaN(9,1))
+%!assert <*65405> (median (NaN(9,1), 3, "omitnan"), NaN(9,1))
+%!assert <*65405> (median (NaN(9,2), 1, "omitnan"), NaN(1,2))
+%!assert <*65405> (median (NaN(9,2), 2, "omitnan"), NaN(9,1))
+%!assert <*65405> (median (NaN(9,2), "omitnan"), NaN(1,2))
+
+## Test single inputs
 %!assert (median (NaN("single")), NaN("single"))
 %!assert (median (NaN("single"), "omitnan"), NaN("single"))
 %!assert (median (NaN("single"), "double"), NaN("double"))


### PR DESCRIPTION
as per https://savannah.gnu.org/bugs/index.php?65405

codepath with 'omitnan' and vectors in median mishandled all-nan case.  add shortcut codepath for median to handle all-nan's, and add BISTs to median and mad for related cases. 