### PR TITLE
mad.m:  correct mad handling of vectors with multiple Infs

### DIFF
--- a/inst/shadow9/mad.m
+++ b/inst/shadow9/mad.m
@@ -237,7 +237,7 @@ function m = mad (x, flag=0, varargin)
         v = sort (abs (x - c));
         m = (v(k) + v(k + 1)) / 2;
       endif
-      m(sum (isinf (x)) > 0) = Inf;
+      m(sum (isinf (x)) >= 0.5 * numel (x)) = Inf;
 
     else              # Compute mean absolute deviation
       x = x(! isnan (x));
@@ -351,13 +351,37 @@ endfunction
 %!assert (mad ([-Inf Inf], 1), NaN)
 %!assert (mad ([3 Inf]), Inf)
 %!assert (mad ([3 4 Inf]), Inf)
-%!assert (mad ([3 4 Inf], 1), Inf)
 %!assert (mad ([Inf 3 4]), Inf)
-%!assert (mad ([Inf 3 4], 1), Inf)
 %!assert (mad ([Inf 3 Inf]), Inf)
 %!assert (mad ([Inf 3 Inf], 1), Inf)
 %!assert (mad ([1 2; 3 Inf]), [1 Inf])
 %!assert (mad ([1 2; 3 Inf], 1), [1 Inf])
+
+%!assert (mad ([3, 4, Inf]), Inf)
+%!assert (mad ([Inf, 3, 4]), Inf)
+%!assert (mad ([3, 4, Inf], 0), Inf)
+%!assert (mad ([3, 4, Inf], 0, 1), [0, 0, NaN])
+%!assert (mad ([3, 4, Inf], 0, 2), Inf)
+%!assert (mad ([3, 4, Inf], 0, 3), [0, 0, NaN])
+%!assert (mad ([3, 4, Inf]', 0), Inf)
+%!assert (mad ([3, 4, Inf]', 0, 1), Inf)
+%!assert (mad ([3, 4, Inf]', 0, 2), [0; 0; NaN])
+%!assert (mad ([3, 4, Inf]', 0, 3), [0; 0; NaN])
+
+%!assert (mad ([Inf, 3, 4], 1), 1)
+%!assert (mad ([3, 4, Inf], 1), 1)
+%!assert (mad ([3, 4, Inf], 1, 1), [0, 0, NaN])
+%!assert (mad ([3, 4, Inf], 1, 2), 1)
+%!assert (mad ([3, 4, Inf], 1, 3), [0, 0, NaN])
+%!assert (mad ([3, 4, Inf]', 1), 1)
+%!assert (mad ([3, 4, Inf]', 1, 1), 1)
+%!assert (mad ([3, 4, Inf]', 1, 2), [0; 0; NaN])
+%!assert (mad ([3, 4, Inf]', 1, 3), [0; 0; NaN])
+
+%!assert (mad ([3, Inf, Inf], 1), Inf)
+%!assert (mad ([3, 4, 5, Inf], 1), 1)
+%!assert (mad ([3, 4, Inf, Inf], 1), Inf)
+%!assert (mad ([3, Inf, Inf, Inf], 1), Inf)
 
 %!assert (mad ([]), NaN)
 %!assert (mad (ones(1,0)), NaN)


### PR DESCRIPTION
*inst/shadow9/mad.m:  Fix condition for replacing output with Inf when using median.  Unlike with mean, instead of condition being when number of Infs is > 0, it should be when it is >numel(x)/2.  The Inf only affects the output when the sorted middle value is Inf.  (also working up fix for similar issue in core so outputs should be compatible.)