### PR TITLE
Make the BIST in glmfit.m reproducible

### DIFF
--- a/inst/glmfit.m
+++ b/inst/glmfit.m
@@ -133,6 +133,7 @@ endfunction
 %! X = rand (50, 1);
 %! b_true = [0.4; 1.5];
 %! mu_true = exp (b_true(1) + b_true(2) * X);
+%! randp ("seed", 1);
 %! y = poissrnd (mu_true);
 %! b = glmfit(X, y, "poisson", "link", "log");
 %! assert(b(1), b_true(1), 0.5);


### PR DESCRIPTION
The BIST for glmfit in not reprodubible:

```
pkg load statistics
while (test ("glmfit", "verbose")) ; endwhile
```

The code above must run forever, but it eventually stops with a failure message like this:

```
!!!!! test failed
ASSERT errors for:  assert (b (2),b_true (2),0.5)

  Location  |  Observed  |  Expected  |  Reason
     ()        0.89439        1.5        Abs err 0.60561 exceeds tol 0.5 by 0.1
```

This is due to the fact that `poissrnd` returns a different value for each call of the BIST. A call to `randp("seed",V)` is necessary for making the BiST reproducible.

