### PR TITLE
Correct median value of binomial distribution when p = 0.5 and N is odd

### DIFF
--- a/inst/dist_obj/BinomialDistribution.m
+++ b/inst/dist_obj/BinomialDistribution.m
@@ -284,7 +284,11 @@ classdef BinomialDistribution
         Fa_b = binocdf ([lx, ux], this.N, this.p);
         m = binoinv (sum (Fa_b) / 2, this.N, this.p);
       else
-        m = binoinv (0.5, this.N, this.p);
+        if (! __traditional__() & this.p == 0.5 & rem (this.N, 2) == 1)
+          m = this.mean ();
+        else
+          m = binoinv (0.5, this.N, this.p);
+        endif
       endif
     endfunction
 
@@ -662,7 +666,7 @@ endfunction
 #%!assert (iqr (t), 1);
 %!assert (mean (pd), 2.5, 1e-10);
 #%!assert (mean (t), 2.8, 1e-10);
-%!assert (median (pd), 3);
+%!assert (median (pd), 2.5);
 #%!assert (median (t), 3);
 %!assert (pdf (pd, [0:5]), [0.0312, 0.1562, 0.3125, 0.3125, 0.1562, 0.0312], 1e-4);
 #%!assert (pdf (t, [0:5]), [0, 0, 0.4, 0.4, 0.2, 0], 1e-4);


### PR DESCRIPTION
For a thorough discussion on this issue, see:

Nowakowski S (2021) Uniqueness of a median of a binomial distribution with rational probability. Advances in Mathematics: Scientific Journal 10(4):1951-1958. (http://dx.doi.org/10.37418/amsj.10.4.9)

Essentially, when p = 0.5 and N is odd, there would be two "median values" (both integer values around N/2). In this case, the median value should be the fully trimmed mid-range, which happens to be equal to the mean value.

Notice that these changes only cope with the untruncated case. For the general truncated case, the solution seems not to be straightforward. In particular, the code below:

```
pd = BinomialDistribution (5, 0.5);
t = truncate (pd, 0, 5)
t.median ()
```

will produce value `3`, which is wrong (it should be `2.5`).

At any rate, this change is bug-compatible with Matlab, thanks to the use of `__traditional_()`.