### PR TITLE
Make BIST in fpdf.m reproducible

### DIFF
--- a/inst/dist_fun/fpdf.m
+++ b/inst/dist_fun/fpdf.m
@@ -108,6 +108,7 @@ endfunction
 %!assert (fpdf (x, 2, [0 NaN Inf 2 2]), [NaN NaN NaN y(4:5)], eps)
 %!assert (fpdf ([x, NaN], 2, 2), [y, NaN], eps)
 %!test #F (x, 1, df1) == T distribution (sqrt (x), df1) / sqrt (x)
+%! rand ("seed", 1234);    # for reproducibility
 %! xr = rand (10,1);
 %! xr = xr(x > 0.1 & x < 0.9);
 %! yr = tpdf (sqrt (xr), 2) ./ sqrt (xr);


### PR DESCRIPTION
The BIST in `inst/dist_fun/fpdf.m` fails randomly:

```
octave:1> pkg load statistics
octave:2> while 1 ; if ! test("fpdf", "verbose") ; break ; endif ; endwhile
[…]
!!!!! test failed
ASSERT errors for:  assert (fpdf (xr, 1, 2),yr,5 * eps)

  Location  |  Observed  |  Expected  |  Reason
     ()         4.4017       4.4017      Abs err 2.6645e-15 exceeds tol 1.1102e-15 by 2e-15
shared variables 
    x =

      -1.0000        0   0.5000   1.0000   2.0000

    y =

            0        0   0.4444   0.2500   0.1111
```

This proposed commit fixes the problem, by using `rand("seed")`.