### PR TITLE
Bug fix in "upper" argument for the cdf of the Chi-square distribution

### DIFF
--- a/inst/dist_fun/chi2cdf.m
+++ b/inst/dist_fun/chi2cdf.m
@@ -49,8 +49,10 @@ function p = chi2cdf (x, df, uflag)
   endif
 
   ## Check for valid "upper" flag
-  if (nargin > 2 && ! strcmpi (uflag, "upper"))
-    error ("chi2cdf: invalid argument for upper tail.");
+  if (nargin > 2) 
+    if ! strcmpi (uflag, "upper")
+      error ("chi2cdf: invalid argument for upper tail.");
+    end
   else
     uflag = [];
   endif


### PR DESCRIPTION
Currently the Chi-square cumulative distribution function produces the same output regardless of the value of the "upper" argument: 

```
> pkg load statistics
> chi2cdf(50,50)
ans = 0.5266
> chi2cdf(50,50, "upper")
ans = 0.5266
```

This seems to be due to an issue in the initial 'Check for valid "upper" flag' that always makes the `uflag` empty. 

The proposed fix solves this issue:

```
> chi2cdf(50,50)
ans = 0.5266
> chi2cdf(50,50, "upper")
ans = 0.4734
> chi2cdf2(50,50, "wrong_arg")
error: chi2cdf: invalid argument for upper tail.
error: called from
    chi2cdf2 at line 11 column 7
```

Thanks for providing the community with this great package!