### PR TITLE
Removed the extra '@' in help strings

### DIFF
--- a/inst/@cvpartition/cvpartition.m
+++ b/inst/@cvpartition/cvpartition.m
@@ -66,7 +66,7 @@
 ## Partition type.
 ## @end table
 ##
-## @seealso{crossval, @@cvpartition/display}
+## @seealso{crossval, @cvpartition/display}
 ## @end deftypefn
 
 function C = cvpartition (X, partition_type = "KFold", k = [])

--- a/inst/@cvpartition/display.m
+++ b/inst/@cvpartition/display.m
@@ -20,7 +20,7 @@
 ##
 ## Display a @samp{cvpartition} object, @var{C}.
 ##
-## @seealso{@@cvpartition/cvpartition}
+## @seealso{@cvpartition/cvpartition}
 ## @end deftypefn
 
 function display (C)

--- a/inst/@cvpartition/get.m
+++ b/inst/@cvpartition/get.m
@@ -20,7 +20,7 @@
 ##
 ## Get a field, @var{f}, from a @samp{cvpartition} object, @var{C}.
 ##
-## @seealso{@@cvpartition/cvpartition}
+## @seealso{@cvpartition/cvpartition}
 ## @end deftypefn
 
 function s = get (c, f)

--- a/inst/@cvpartition/repartition.m
+++ b/inst/@cvpartition/repartition.m
@@ -24,7 +24,7 @@
 ## partition_type as @var{C} but redo any randomization performed (currently,
 ## only the HoldOut type uses randomization).
 ##
-## @seealso{@@cvpartition/cvpartition}
+## @seealso{@cvpartition/cvpartition}
 ## @end deftypefn
 
 function Cnew = repartition (C)

--- a/inst/@cvpartition/set.m
+++ b/inst/@cvpartition/set.m
@@ -20,7 +20,7 @@
 ##
 ## Set @var{field}, in a @samp{cvpartition} object, @var{C}.
 ##
-## @seealso{@@cvpartition/cvpartition}
+## @seealso{@cvpartition/cvpartition}
 ## @end deftypefn
 
 function s = set (c, varargin)

--- a/inst/@cvpartition/test.m
+++ b/inst/@cvpartition/test.m
@@ -21,7 +21,7 @@
 ## Return logical vector for testing-subset indices from a @samp{cvpartition}
 ## object, @var{C}.  @var{i} is the fold index (default is 1).
 ##
-## @seealso{@@cvpartition/cvpartition, @@cvpartition/training}
+## @seealso{@cvpartition/cvpartition, @cvpartition/training}
 ## @end deftypefn
 
 function inds = test (C, i = [])

--- a/inst/@cvpartition/training.m
+++ b/inst/@cvpartition/training.m
@@ -21,7 +21,7 @@
 ## Return logical vector for training-subset indices from a @samp{cvpartition}
 ## object, @var{C}.  @var{i} is the fold index (default is 1).
 ##
-## @seealso{@@cvpartition/cvpartition, @@cvpartition/test}
+## @seealso{@cvpartition/cvpartition, @cvpartition/test}
 ## @end deftypefn
 
 function inds = training (C, i = [])


### PR DESCRIPTION
Fixes #176 
- Removed all the extra '@' in the help strings across 7 files.