### PR TITLE
[GSoC] Add ExhaustiveSearcher Class

### DIFF
--- a/INDEX
+++ b/INDEX
@@ -8,6 +8,7 @@ Clustering
  crossval
  editDistance
  evalclusters
+ ExhaustiveSearcher
  inconsistent
  kmeans
  knnsearch

--- a/inst/ExhaustiveSearcher.m
+++ b/inst/ExhaustiveSearcher.m
@@ -1,0 +1,540 @@
+## Copyright (C) 2025 Swayam Shah <swayamshah66@gmail.com>
+##
+## This file is part of the statistics package for GNU Octave.
+##
+## This program is free software; you can redistribute it and/or modify it under
+## the terms of the GNU General Public License as published by the Free Software
+## Foundation; either version 3 of the License, or (at your option) any later
+## version.
+##
+## This program is distributed in the hope that it will be useful, but WITHOUT
+## ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+## FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+## details.
+##
+## You should have received a copy of the GNU General Public License along with
+## this program; if not, see <http://www.gnu.org/licenses/>.
+
+## -*- texinfo -*-
+## @deftypefn  {statistics} {@var{obj} =} ExhaustiveSearcher (@var{X})
+## @deftypefnx {statistics} {@var{obj} =} ExhaustiveSearcher (@var{X}, @var{name}, @var{value})
+##
+## Create an @qcode{ExhaustiveSearcher} object for nearest neighbor searches.
+##
+## @code{@var{obj} = ExhaustiveSearcher (@var{X})} constructs an
+## @code{ExhaustiveSearcher} object using the training data @var{X}.
+## @var{X} must be an @math{NxP} numeric matrix, where rows correspond to
+## observations and columns correspond to features or variables. This object
+## performs exhaustive nearest neighbor searches by computing distances from
+## all points in @var{X} to query points using the specified distance metric.
+##
+## @code{@var{obj} = ExhaustiveSearcher (@var{X}, @var{name}, @var{value})}
+## allows specification of additional parameters via name-value pairs:
+##
+## @multitable @columnfractions 0.18 0.02 0.8
+## @headitem @var{Name} @tab @tab @var{Value}
+##
+## @item @qcode{"Distance"} @tab @tab Distance metric used for searches, specified
+## as a character vector or function handle. Default is @qcode{"euclidean"}. See
+## supported metrics in @code{pdist2}.
+##
+## @item @qcode{"P"} @tab @tab Minkowski distance exponent, specified as a
+## positive scalar. Valid when @qcode{"Distance"} is @qcode{"minkowski"}. Default
+## is 2.
+##
+## @item @qcode{"Scale"} @tab @tab Scale parameter for standardized Euclidean
+## distance, specified as a nonnegative vector matching the number of columns in
+## @var{X}. Valid when @qcode{"Distance"} is @qcode{"seuclidean"}. Default is the
+## standard deviation of @var{X}.
+##
+## @item @qcode{"Cov"} @tab @tab Covariance matrix for Mahalanobis distance,
+## specified as a positive definite matrix matching the number of columns in
+## @var{X}. Valid when @qcode{"Distance"} is @qcode{"mahalanobis"}. Default is
+## the covariance of @var{X}.
+## @end multitable
+##
+## An @qcode{ExhaustiveSearcher} object, @var{obj}, stores the training data and
+## various parameters for nearest neighbor searches, which can be accessed in
+## the following fields:
+##
+## @multitable @columnfractions 0.23 0.02 0.75
+## @headitem @var{Field} @tab @tab @var{Description}
+##
+## @item @qcode{X} @tab @tab Training data, specified as an @math{NxP} numeric
+## matrix. Each column of @var{X} represents one predictor (variable), and each
+## row represents one observation.
+##
+## @item @qcode{Distance} @tab @tab Distance metric used for searches, specified
+## as a character vector or function handle.
+##
+## @item @qcode{DistParameter} @tab @tab Parameter for the distance metric,
+## specified as a scalar, vector, or matrix depending on the distance metric.
+## Empty for unsupported metrics.
+## @end multitable
+##
+## @strong{Methods:}
+## @itemize
+## @item @code{knnsearch}: Find the @math{K} nearest neighbors.
+## @item @code{rangesearch}: Find all neighbors within a specified radius.
+## @end itemize
+##
+## @seealso{knnsearch, rangesearch, pdist2}
+## @end deftypefn
+
+classdef ExhaustiveSearcher < handle
+
+  properties (SetAccess = private)
+    X             # Training data
+  endproperties
+
+  properties
+    Distance = "euclidean"    # Distance metric
+    DistParameter             # Distance metric parameter
+  endproperties
+
+  methods
+
+    ## -*- texinfo -*-
+    ## @deftypefn  {ExhaustiveSearcher} {@var{obj} =} ExhaustiveSearcher (@var{X})
+    ## @deftypefnx {ExhaustiveSearcher} {@var{obj} =} ExhaustiveSearcher (@var{X}, @var{name}, @var{value})
+    ##
+    ## Construct an @qcode{ExhaustiveSearcher} object.
+    ##
+    ## @code{@var{obj} = ExhaustiveSearcher (@var{X})} creates an
+    ## @qcode{ExhaustiveSearcher} object with the training data @var{X},
+    ## using the default Euclidean distance metric.
+    ##
+    ## @code{@var{obj} = ExhaustiveSearcher (@var{X}, @var{name}, @var{value})}
+    ## constructs an @qcode{ExhaustiveSearcher} object with additional
+    ## parameters specified by name-value pairs as described in the class
+    ## documentation.
+    ##
+    ## @seealso{ExhaustiveSearcher, knnsearch, rangesearch}
+    ## @end deftypefn
+    function obj = ExhaustiveSearcher (X, varargin)
+      if (nargin < 1)
+        error ("ExhaustiveSearcher: too few input arguments.");
+      endif
+
+      if (! (isnumeric (X) && ismatrix (X) && all (isfinite (X)(:))))
+        error ("ExhaustiveSearcher: X must be a finite numeric matrix.");
+      endif
+
+      obj.X = X;
+
+      ## Default values for optional parameters
+      P = [];
+      S = [];
+      C = [];
+
+      ## Parse name-value pairs
+      i = 1;
+      while (i <= length (varargin))
+        if (! ischar (varargin{i}))
+          error ("ExhaustiveSearcher: name arguments must be character vectors.");
+        endif
+        switch (tolower (varargin{i}))
+          case "distance"
+            if (i + 1 > length (varargin))
+              error ("ExhaustiveSearcher: 'Distance' requires a value.");
+            endif
+            obj.Distance = varargin{i+1};
+            i += 2;
+          case "p"
+            if (i + 1 > length (varargin))
+              error ("ExhaustiveSearcher: 'P' requires a value.");
+            endif
+            P = varargin{i+1};
+            i += 2;
+          case "scale"
+            if (i + 1 > length (varargin))
+              error ("ExhaustiveSearcher: 'Scale' requires a value.");
+            endif
+            S = varargin{i+1};
+            i += 2;
+          case "cov"
+            if (i + 1 > length (varargin))
+              error ("ExhaustiveSearcher: 'Cov' requires a value.");
+            endif
+            C = varargin{i+1};
+            i += 2;
+          otherwise
+            error ("ExhaustiveSearcher: invalid NAME: '%s'.", varargin{i});
+        endswitch
+      endwhile
+
+      ## Validate and set distance metric
+      valid_metrics = {"euclidean", "minkowski", "seuclidean", "mahalanobis", ...
+                       "cityblock", "manhattan", "chebychev", "cosine", ...
+                       "correlation", "spearman", "hamming", "jaccard"};
+      if (ischar (obj.Distance))
+        if (! any (strcmpi (valid_metrics, obj.Distance)))
+          error ("ExhaustiveSearcher: unsupported distance metric '%s'.", ...
+                 obj.Distance);
+        endif
+      elseif (isa (obj.Distance, "function_handle"))
+        try
+          D = obj.Distance (X(1,:), X);
+          if (! isvector (D) || length (D) != rows (X))
+            error ("ExhaustiveSearcher: custom distance function output invalid.");
+          endif
+        catch
+          error ("ExhaustiveSearcher: invalid distance function handle.");
+        end_try_catch
+      else
+        error ("ExhaustiveSearcher: Distance must be a string or function handle.");
+      endif
+
+      ## Set DistParameter based on Distance
+      if (strcmpi (obj.Distance, "minkowski"))
+        if (isempty (P))
+          obj.DistParameter = 2;
+        else
+          if (! (isscalar (P) && isnumeric (P) && P > 0 && isfinite (P)))
+            error ("ExhaustiveSearcher: P must be a positive finite scalar.");
+          endif
+          obj.DistParameter = P;
+        endif
+      elseif (strcmpi (obj.Distance, "seuclidean"))
+        if (isempty (S))
+          obj.DistParameter = std (X, [], 1);
+        else
+          if (! (isvector (S) && isnumeric (S) && all (S >= 0) && ...
+                 all (isfinite (S)) && length (S) == columns (X)))
+            error ("ExhaustiveSearcher: Scale must be a nonnegative vector matching X columns.");
+          endif
+          obj.DistParameter = S;
+        endif
+      elseif (strcmpi (obj.Distance, "mahalanobis"))
+        if (isempty (C))
+          obj.DistParameter = cov (X);
+        else
+          if (! (ismatrix (C) && isnumeric (C) && all (isfinite (C)(:)) && ...
+                 rows (C) == columns (C) && rows (C) == columns (X)))
+            error ("ExhaustiveSearcher: Cov must be a square matrix matching X columns.");
+          endif
+          [~, p] = chol (C);
+          if (p != 0)
+            error ("ExhaustiveSearcher: Cov must be positive definite.");
+          endif
+          obj.DistParameter = C;
+        endif
+      else
+        obj.DistParameter = [];
+      endif
+    endfunction
+
+    ## -*- texinfo -*-
+    ## @deftypefn  {ExhaustiveSearcher} {[@var{idx}, @var{D}] =} knnsearch (@var{obj}, @var{Y}, @var{K})
+    ## @deftypefnx {ExhaustiveSearcher} {[@var{idx}, @var{D}] =} knnsearch (@var{obj}, @var{Y}, @var{K}, @var{name}, @var{value})
+    ##
+    ## Find the @math{K} nearest neighbors in the training data to query points.
+    ##
+    ## @code{[@var{idx}, @var{D}] = knnsearch (@var{obj}, @var{Y}, @var{K})}
+    ## returns the indices @var{idx} and distances @var{D} of the @math{K} nearest
+    ## neighbors in @var{obj.X} to each point in @var{Y}, using the distance metric
+    ## specified in @var{obj.Distance}.
+    ##
+    ## @itemize
+    ## @item @var{obj} is an @qcode{ExhaustiveSearcher} object.
+    ## @item @var{Y} is an @math{MxP} numeric matrix of query points, where @math{P}
+    ## must match the number of columns in @var{obj.X}.
+    ## @item @var{K} is a positive integer specifying the number of nearest
+    ## neighbors to find.
+    ## @end itemize
+    ##
+    ## @code{[@var{idx}, @var{D}] = knnsearch (@var{obj}, @var{Y}, @var{K}, @var{name}, @var{value})}
+    ## allows additional options via name-value pairs:
+    ##
+    ## @multitable @columnfractions 0.18 0.02 0.8
+    ## @headitem @var{Name} @tab @tab @var{Value}
+    ##
+    ## @item @qcode{"IncludeTies"} @tab @tab Logical flag indicating whether to
+    ## include all neighbors tied with the @math{K}th smallest distance. Default
+    ## is @qcode{false}. If @qcode{true}, @var{idx} and @var{D} are cell arrays.
+    ## @end multitable
+    ##
+    ## @var{idx} contains the indices of the nearest neighbors in @var{obj.X}.
+    ## @var{D} contains the corresponding distances.
+    ##
+    ## @seealso{ExhaustiveSearcher, rangesearch, pdist2}
+    ## @end deftypefn
+    function [idx, D] = knnsearch (obj, Y, K, varargin)
+      if (nargin < 3)
+        error ("ExhaustiveSearcher.knnsearch: too few input arguments.");
+      endif
+
+      if (! (isnumeric (Y) && ismatrix (Y) && all (isfinite (Y)(:))))
+        error ("ExhaustiveSearcher.knnsearch: Y must be a finite numeric matrix.");
+      endif
+
+      if (size (obj.X, 2) != size (Y, 2))
+        error ("ExhaustiveSearcher.knnsearch: number of columns in X and Y must match.");
+      endif
+
+      if (! (isscalar (K) && isnumeric (K) && K >= 1 && K == fix (K) && isfinite (K)))
+        error ("ExhaustiveSearcher.knnsearch: K must be a positive integer.");
+      endif
+
+      ## Parse options
+      IncludeTies = false;
+      i = 1;
+      while (i <= length (varargin))
+        if (! ischar (varargin{i}))
+          error ("ExhaustiveSearcher.knnsearch: name arguments must be character vectors.");
+        endif
+        switch (tolower (varargin{i}))
+          case "includeties"
+            if (i + 1 > length (varargin))
+              error ("ExhaustiveSearcher.knnsearch: 'IncludeTies' requires a value.");
+            endif
+            IncludeTies = varargin{i+1};
+            if (! (islogical (IncludeTies) && isscalar (IncludeTies)))
+              error ("ExhaustiveSearcher.knnsearch: IncludeTies must be a logical scalar.");
+            endif
+            i += 2;
+          otherwise
+            error ("ExhaustiveSearcher.knnsearch: invalid NAME: '%s'.", varargin{i});
+        endswitch
+      endwhile
+
+      ## Compute distance matrix
+      D_mat = pdist2 (obj.X, Y, obj.Distance, obj.DistParameter);
+      D_mat = reshape (D_mat', size (Y, 1), size (obj.X, 1));
+
+      if (K == 1 && ! IncludeTies)
+        [D, idx] = min (D_mat, [], 2);
+      else
+        [sorted_D, sorted_idx] = sort (D_mat, 2);
+        if (IncludeTies)
+          idx = cell (rows (Y), 1);
+          D = cell (rows (Y), 1);
+          for i = 1:rows (Y)
+            if (K > columns (sorted_D))
+              kth_dist = sorted_D(i, end);
+            else
+              kth_dist = sorted_D(i, K);
+            endif
+            tie_idx = find (sorted_D(i, :) <= kth_dist);
+            idx{i} = sorted_idx(i, tie_idx);
+            D{i} = sorted_D(i, tie_idx);
+          endfor
+        else
+          idx = sorted_idx(:, 1:K);
+          D = sorted_D(:, 1:K);
+        endif
+      endif
+    endfunction
+
+    ## -*- texinfo -*-
+    ## @deftypefn  {ExhaustiveSearcher} {[@var{idx}, @var{D}] =} rangesearch (@var{obj}, @var{Y}, @var{r})
+    ## @deftypefnx {ExhaustiveSearcher} {[@var{idx}, @var{D}] =} rangesearch (@var{obj}, @var{Y}, @var{r}, @var{name}, @var{value})
+    ##
+    ## Find all neighbors within a specified radius of query points.
+    ##
+    ## @code{[@var{idx}, @var{D}] = rangesearch (@var{obj}, @var{Y}, @var{r})}
+    ## returns the indices @var{idx} and distances @var{D} of all points in
+    ## @var{obj.X} within radius @var{r} of each point in @var{Y}, using the
+    ## distance metric specified in @var{obj.Distance}.
+    ##
+    ## @itemize
+    ## @item @var{obj} is an @qcode{ExhaustiveSearcher} object.
+    ## @item @var{Y} is an @math{MxP} numeric matrix of query points, where @math{P}
+    ## must match the number of columns in @var{obj.X}.
+    ## @item @var{r} is a nonnegative scalar specifying the search radius.
+    ## @end itemize
+    ##
+    ## @code{[@var{idx}, @var{D}] = rangesearch (@var{obj}, @var{Y}, @var{r}, @var{name}, @var{value})}
+    ## allows additional options via name-value pairs:
+    ##
+    ## @multitable @columnfractions 0.18 0.02 0.8
+    ## @headitem @var{Name} @tab @tab @var{Value}
+    ##
+    ## @item @qcode{"SortIndices"} @tab @tab Logical flag indicating whether to
+    ## sort the indices by distance. Default is @qcode{true}.
+    ## @end multitable
+    ##
+    ## @var{idx} and @var{D} are cell arrays where each cell contains the indices
+    ## and distances for one query point in @var{Y}.
+    ##
+    ## @seealso{ExhaustiveSearcher, knnsearch, pdist2}
+    ## @end deftypefn
+    function [idx, D] = rangesearch (obj, Y, r, varargin)
+      if (nargin < 3)
+        error ("ExhaustiveSearcher.rangesearch: too few input arguments.");
+      endif
+
+      if (! (isnumeric (Y) && ismatrix (Y) && all (isfinite (Y)(:))))
+        error ("ExhaustiveSearcher.rangesearch: Y must be a finite numeric matrix.");
+      endif
+
+      if (size (obj.X, 2) != size (Y, 2))
+        error ("ExhaustiveSearcher.rangesearch: number of columns in X and Y must match.");
+      endif
+
+      if (! (isscalar (r) && isnumeric (r) && r >= 0 && isfinite (r)))
+        error ("ExhaustiveSearcher.rangesearch: r must be a nonnegative finite scalar.");
+      endif
+
+      ## Parse options
+      SortIndices = true;
+      i = 1;
+      while (i <= length (varargin))
+        if (! ischar (varargin{i}))
+          error ("ExhaustiveSearcher.rangesearch: name arguments must be character vectors.");
+        endif
+        switch (tolower (varargin{i}))
+          case "sortindices"
+            if (i + 1 > length (varargin))
+              error ("ExhaustiveSearcher.rangesearch: 'SortIndices' requires a value.");
+            endif
+            SortIndices = varargin{i+1};
+            if (! (islogical (SortIndices) && isscalar (SortIndices)))
+              error ("ExhaustiveSearcher.rangesearch: SortIndices must be a logical scalar.");
+            endif
+            i += 2;
+          otherwise
+            error ("ExhaustiveSearcher.rangesearch: invalid NAME: '%s'.", varargin{i});
+        endswitch
+      endwhile
+
+      ## Compute distance matrix
+      D_mat = pdist2 (obj.X, Y, obj.Distance, obj.DistParameter);
+      D_mat = reshape (D_mat', size (Y, 1), size (obj.X, 1));
+
+      idx = cell (rows (Y), 1);
+      D = cell (rows (Y), 1);
+      for i = 1:rows (Y)
+        within_r = find (D_mat(i, :) <= r);
+        if (SortIndices)
+          [sorted_D, sort_idx] = sort (D_mat(i, within_r));
+          idx{i} = within_r(sort_idx);
+          D{i} = sorted_D;
+        else
+          idx{i} = within_r;
+          D{i} = D_mat(i, within_r);
+        endif
+      endfor
+    endfunction
+
+  endmethods
+
+endclassdef
+
+## Demo Examples
+
+%!demo
+%! ## Create an ExhaustiveSearcher object with Euclidean distance
+%! X = [1, 2; 3, 4; 5, 6];
+%! obj = ExhaustiveSearcher (X);
+%! ## Find the nearest neighbor to [2, 3]
+%! Y = [2, 3];
+%! [idx, D] = knnsearch (obj, Y, 1);
+%! disp ("Nearest neighbor index:"); disp (idx);
+%! disp ("Distance:"); disp (D);
+%! ## Find all points within radius 2 from [2, 3]
+%! [idx, D] = rangesearch (obj, Y, 2);
+%! disp ("Indices within radius:"); disp (idx);
+%! disp ("Distances:"); disp (D);
+
+%!demo
+%! ## Create an ExhaustiveSearcher object with Minkowski distance (P=1)
+%! X = [0, 0; 1, 0; 0, 1];
+%! obj = ExhaustiveSearcher (X, "Distance", "minkowski", "P", 1);
+%! ## Find the 2 nearest neighbors to [0.5, 0.5]
+%! Y = [0.5, 0.5];
+%! [idx, D] = knnsearch (obj, Y, 2);
+%! disp ("Nearest neighbor indices:"); disp (idx);
+%! disp ("Distances:"); disp (D);
+%! ## Find points within radius 1, unsorted
+%! [idx, D] = rangesearch (obj, Y, 1, "SortIndices", false);
+%! disp ("Indices within radius:"); disp (idx);
+%! disp ("Distances:"); disp (D);
+
+## Test Cases
+
+%!test
+%! ## Basic constructor test with default settings
+%! X = [1, 2; 3, 4; 5, 6];
+%! obj = ExhaustiveSearcher (X);
+%! assert (obj.X, X)
+%! assert (obj.Distance, "euclidean")
+%! assert (isempty (obj.DistParameter))
+
+%!test
+%! ## Constructor with Minkowski distance and custom P
+%! X = [1, 2; 3, 4];
+%! obj = ExhaustiveSearcher (X, "Distance", "minkowski", "P", 3);
+%! assert (obj.Distance, "minkowski")
+%! assert (obj.DistParameter, 3)
+
+%!test
+%! ## knnsearch with K=1
+%! X = [1, 2; 3, 4; 5, 6];
+%! obj = ExhaustiveSearcher (X);
+%! Y = [2, 3];
+%! [idx, D] = knnsearch (obj, Y, 1);
+%! assert (idx, 1)
+%! assert (D, sqrt (2), 1e-10)
+
+%!test
+%! ## knnsearch with K=2 and IncludeTies
+%! X = [1, 2; 3, 4; 5, 6];
+%! obj = ExhaustiveSearcher (X);
+%! Y = [2, 3];
+%! [idx, D] = knnsearch (obj, Y, 2, "IncludeTies", true);
+%! assert (iscell (idx))
+%! assert (idx{1}, [1, 2])
+%! assert (D{1}, [sqrt(2), sqrt(2)], 1e-10)
+
+%!test
+%! ## rangesearch with default SortIndices
+%! X = [1, 1; 2, 2; 3, 3];
+%! obj = ExhaustiveSearcher (X);
+%! Y = [0, 0];
+%! [idx, D] = rangesearch (obj, Y, 2);
+%! assert (idx{1}, [1])
+%! assert (D{1}, [sqrt(2)], 1e-10)
+
+%!test
+%! ## rangesearch with SortIndices=false
+%! X = [1, 1; 2, 2; 3, 3];
+%! obj = ExhaustiveSearcher (X);
+%! Y = [0, 0];
+%! [idx, D] = rangesearch (obj, Y, 3, "SortIndices", false);
+%! assert (idx{1}, [1, 2])
+%! assert (D{1}, [sqrt(2), sqrt(8)], 1e-10)
+
+## Test Input Validation
+
+%!error<ExhaustiveSearcher: too few input arguments.> ExhaustiveSearcher ()
+%!error<ExhaustiveSearcher: X must be a finite numeric matrix.> ExhaustiveSearcher ("abc")
+%!error<ExhaustiveSearcher: X must be a finite numeric matrix.> ExhaustiveSearcher ([1; Inf; 3])
+%!error<ExhaustiveSearcher: name arguments must be character vectors.> ExhaustiveSearcher (ones(3,2), 1, "value")
+%!error<ExhaustiveSearcher: 'Distance' requires a value.> ExhaustiveSearcher (ones(3,2), "Distance")
+%!error<ExhaustiveSearcher: unsupported distance metric 'invalid'.> ExhaustiveSearcher (ones(3,2), "Distance", "invalid")
+%!error<ExhaustiveSearcher: invalid distance function handle.> ExhaustiveSearcher (ones(3,2), "Distance", @(x) x)
+%!error<ExhaustiveSearcher: Distance must be a string or function handle.> ExhaustiveSearcher (ones(3,2), "Distance", 1)
+%!error<ExhaustiveSearcher: P must be a positive finite scalar.> ExhaustiveSearcher (ones(3,2), "Distance", "minkowski", "P", -1)
+%!error<ExhaustiveSearcher: Scale must be a nonnegative vector matching X columns.> ExhaustiveSearcher (ones(3,2), "Distance", "seuclidean", "Scale", [-1, 1])
+%!error<ExhaustiveSearcher: Cov must be a square matrix matching X columns.> ExhaustiveSearcher (ones(3,2), "Distance", "mahalanobis", "Cov", ones(3,3))
+%!error<ExhaustiveSearcher: Cov must be positive definite.> ExhaustiveSearcher (ones(3,2), "Distance", "mahalanobis", "Cov", -eye(2))
+%!error<ExhaustiveSearcher: invalid NAME: 'foo'.> ExhaustiveSearcher (ones(3,2), "foo", "bar")
+
+%!error<ExhaustiveSearcher.knnsearch: too few input arguments.> knnsearch (ExhaustiveSearcher (ones(3,2)))
+%!error<ExhaustiveSearcher.knnsearch: Y must be a finite numeric matrix.> knnsearch (ExhaustiveSearcher (ones(3,2)), "abc", 1)
+%!error<ExhaustiveSearcher.knnsearch: number of columns in X and Y must match.> knnsearch (ExhaustiveSearcher (ones(3,2)), ones(3,3), 1)
+%!error<ExhaustiveSearcher.knnsearch: K must be a positive integer.> knnsearch (ExhaustiveSearcher (ones(3,2)), ones(3,2), 0)
+%!error<ExhaustiveSearcher.knnsearch: name arguments must be character vectors.> knnsearch (ExhaustiveSearcher (ones(3,2)), ones(3,2), 1, 1, true)
+%!error<ExhaustiveSearcher.knnsearch: 'IncludeTies' requires a value.> knnsearch (ExhaustiveSearcher (ones(3,2)), ones(3,2), 1, "IncludeTies")
+%!error<ExhaustiveSearcher.knnsearch: IncludeTies must be a logical scalar.> knnsearch (ExhaustiveSearcher (ones(3,2)), ones(3,2), 1, "IncludeTies", 1)
+%!error<ExhaustiveSearcher.knnsearch: invalid NAME: 'foo'.> knnsearch (ExhaustiveSearcher (ones(3,2)), ones(3,2), 1, "foo", "bar")
+
+%!error<ExhaustiveSearcher.rangesearch: too few input arguments.> rangesearch (ExhaustiveSearcher (ones(3,2)))
+%!error<ExhaustiveSearcher.rangesearch: Y must be a finite numeric matrix.> rangesearch (ExhaustiveSearcher (ones(3,2)), "abc", 1)
+%!error<ExhaustiveSearcher.rangesearch: number of columns in X and Y must match.> rangesearch (ExhaustiveSearcher (ones(3,2)), ones(3,3), 1)
+%!error<ExhaustiveSearcher.rangesearch: r must be a nonnegative finite scalar.> rangesearch (ExhaustiveSearcher (ones(3,2)), ones(3,2), -1)
+%!error<ExhaustiveSearcher.rangesearch: name arguments must be character vectors.> rangesearch (ExhaustiveSearcher (ones(3,2)), ones(3,2), 1, 1, true)
+%!error<ExhaustiveSearcher.rangesearch: 'SortIndices' requires a value.> rangesearch (ExhaustiveSearcher (ones(3,2)), ones(3,2), 1, "SortIndices")
+%!error<ExhaustiveSearcher.rangesearch: SortIndices must be a logical scalar.> rangesearch (ExhaustiveSearcher (ones(3,2)), ones(3,2), 1, "SortIndices", 1)
+%!error<ExhaustiveSearcher.rangesearch: invalid NAME: 'foo'.> rangesearch (ExhaustiveSearcher (ones(3,2)), ones(3,2), 1, "foo", "bar")


### PR DESCRIPTION
1. This PR adds ExhaustiveSearcher Class as part of GSoC project regarding adding Clustering *Searcher classes.
2. All the Tests pass locally, so the code is completely tested.

<details><summary>Test Logs</summary>

```matlab
octave:4> pkg test statistics
warning: function /home/swayam-shah/.local/share/octave/api-v58/packages/statistics-1.7.4/shadow9/mean.m shadows a core library function
warning: called from
    /home/swayam-shah/.local/share/octave/api-v58/packages/statistics-1.7.4/PKG_ADD at line 15 column 3
    load_packages_and_dependencies at line 56 column 5
    load_packages at line 53 column 3
    pkg at line 813 column 7

warning: function /home/swayam-shah/.local/share/octave/api-v58/packages/statistics-1.7.4/shadow9/median.m shadows a core library function
warning: called from
    /home/swayam-shah/.local/share/octave/api-v58/packages/statistics-1.7.4/PKG_ADD at line 15 column 3
    load_packages_and_dependencies at line 56 column 5
    load_packages at line 53 column 3
    pkg at line 813 column 7

warning: function /home/swayam-shah/.local/share/octave/api-v58/packages/statistics-1.7.4/shadow9/mad.m shadows a core library function
warning: called from
    /home/swayam-shah/.local/share/octave/api-v58/packages/statistics-1.7.4/PKG_ADD at line 15 column 3
    load_packages_and_dependencies at line 56 column 5
    load_packages at line 53 column 3
    pkg at line 813 column 7

warning: function /home/swayam-shah/.local/share/octave/api-v58/packages/statistics-1.7.4/shadow9/std.m shadows a core library function
warning: called from
    /home/swayam-shah/.local/share/octave/api-v58/packages/statistics-1.7.4/PKG_ADD at line 15 column 3
    load_packages_and_dependencies at line 56 column 5
    load_packages at line 53 column 3
    pkg at line 813 column 7

warning: function /home/swayam-shah/.local/share/octave/api-v58/packages/statistics-1.7.4/shadow9/var.m shadows a core library function
warning: called from
    /home/swayam-shah/.local/share/octave/api-v58/packages/statistics-1.7.4/PKG_ADD at line 15 column 3
    load_packages_and_dependencies at line 56 column 5
    load_packages at line 53 column 3
    pkg at line 813 column 7

Testing functions in package 'statistics':

Integrated test scripts:

  ../api-v58/packages/statistics-1.7.4/@cvpartition/cvpartition.m  pass    8/8   
  ..tave/api-v58/packages/statistics-1.7.4/@cvpartition/display.m  pass    6/6   
  ..e/octave/api-v58/packages/statistics-1.7.4/@cvpartition/get.m  pass    9/9   
  ../api-v58/packages/statistics-1.7.4/@cvpartition/repartition.m  pass    2/2   
  ..e/octave/api-v58/packages/statistics-1.7.4/@cvpartition/set.m  pass    5/5   
  ../octave/api-v58/packages/statistics-1.7.4/@cvpartition/test.m  pass    9/9   
  ..ave/api-v58/packages/statistics-1.7.4/@cvpartition/training.m  pass    9/9   
  ../statistics-1.7.4/Classification/ClassificationDiscriminant.m  pass   66/66  
  ../packages/statistics-1.7.4/Classification/ClassificationGAM.m  pass   35/35  
  ../packages/statistics-1.7.4/Classification/ClassificationKNN.m  pass  165/165 
  ..statistics-1.7.4/Classification/ClassificationNeuralNetwork.m  pass   58/58  
  ..tistics-1.7.4/Classification/ClassificationPartitionedModel.m ******* pass   20/20  
  ../packages/statistics-1.7.4/Classification/ClassificationSVM.m ******* pass  115/115 
  ..tics-1.7.4/Classification/CompactClassificationDiscriminant.m  pass   28/28  
  ..es/statistics-1.7.4/Classification/CompactClassificationGAM.m  pass   10/10  
  ..ics-1.7.4/Classification/CompactClassificationNeuralNetwork.m  pass    5/5   
  ..es/statistics-1.7.4/Classification/CompactClassificationSVM.m  pass   29/29  
  ..ckages/statistics-1.7.4/Classification/ConfusionMatrixChart.m  pass    1/1   
  ..ages/statistics-1.7.4/Clustering/CalinskiHarabaszEvaluation.m  pass    1/1   
  ..i-v58/packages/statistics-1.7.4/Clustering/ClusterCriterion.m  pass    4/4   
  ..ackages/statistics-1.7.4/Clustering/DaviesBouldinEvaluation.m  pass    1/1   
  ../api-v58/packages/statistics-1.7.4/Clustering/GapEvaluation.m  pass    1/1   
  ..8/packages/statistics-1.7.4/Clustering/SilhouetteEvaluation.m  pass    1/1   
  ../api-v58/packages/statistics-1.7.4/Regression/RegressionGAM.m  pass   39/39  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fit/betafit.m  pass   13/13  
  ../octave/api-v58/packages/statistics-1.7.4/dist_fit/betalike.m  pass    8/8   
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fit/binofit.m  pass   10/10  
  ../octave/api-v58/packages/statistics-1.7.4/dist_fit/binolike.m  pass   18/18  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fit/bisafit.m  pass   12/12  
  ../octave/api-v58/packages/statistics-1.7.4/dist_fit/bisalike.m  pass    9/9   
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fit/burrfit.m  pass   15/15  
  ../octave/api-v58/packages/statistics-1.7.4/dist_fit/burrlike.m  pass    8/8   
  ..are/octave/api-v58/packages/statistics-1.7.4/dist_fit/evfit.m  pass    9/9   
  ..re/octave/api-v58/packages/statistics-1.7.4/dist_fit/evlike.m  pass    8/8   
  ..re/octave/api-v58/packages/statistics-1.7.4/dist_fit/expfit.m  pass   47/47  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fit/explike.m  pass    8/8   
  ..re/octave/api-v58/packages/statistics-1.7.4/dist_fit/gamfit.m  pass   23/23  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fit/gamlike.m  pass    8/8   
  ..re/octave/api-v58/packages/statistics-1.7.4/dist_fit/geofit.m  pass   10/10  
  ..re/octave/api-v58/packages/statistics-1.7.4/dist_fit/gevfit.m  pass   11/11  
  ..tave/api-v58/packages/statistics-1.7.4/dist_fit/gevfit_lmom.m  pass    1/1   
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fit/gevlike.m  pass   11/11  
  ..are/octave/api-v58/packages/statistics-1.7.4/dist_fit/gpfit.m  pass   15/15  
  ..re/octave/api-v58/packages/statistics-1.7.4/dist_fit/gplike.m  pass   20/20  
  ..octave/api-v58/packages/statistics-1.7.4/dist_fit/gumbelfit.m  pass   10/10  
  ..ctave/api-v58/packages/statistics-1.7.4/dist_fit/gumbellike.m  pass    8/8   
  ..are/octave/api-v58/packages/statistics-1.7.4/dist_fit/hnfit.m  pass   15/15  
  ..re/octave/api-v58/packages/statistics-1.7.4/dist_fit/hnlike.m  pass    9/9   
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fit/invgfit.m  pass   12/12  
  ../octave/api-v58/packages/statistics-1.7.4/dist_fit/invglike.m  pass    9/9   
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fit/logifit.m  pass   13/13  
  ../octave/api-v58/packages/statistics-1.7.4/dist_fit/logilike.m  pass    8/8   
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fit/loglfit.m  pass   13/13  
  ../octave/api-v58/packages/statistics-1.7.4/dist_fit/logllike.m  pass    8/8   
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fit/lognfit.m  pass   12/12  
  ../octave/api-v58/packages/statistics-1.7.4/dist_fit/lognlike.m  pass   10/10  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fit/nakafit.m  pass   15/15  
  ../octave/api-v58/packages/statistics-1.7.4/dist_fit/nakalike.m  pass   11/11  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fit/nbinfit.m  pass   16/16  
  ../octave/api-v58/packages/statistics-1.7.4/dist_fit/nbinlike.m  pass   16/16  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fit/normfit.m  pass   13/13  
  ../octave/api-v58/packages/statistics-1.7.4/dist_fit/normlike.m  pass   11/11  
  ../octave/api-v58/packages/statistics-1.7.4/dist_fit/poissfit.m  pass   10/10  
  ..octave/api-v58/packages/statistics-1.7.4/dist_fit/poisslike.m  pass    8/8   
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fit/raylfit.m  pass   16/16  
  ../octave/api-v58/packages/statistics-1.7.4/dist_fit/rayllike.m  pass   13/13  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fit/ricefit.m  pass   19/19  
  ../octave/api-v58/packages/statistics-1.7.4/dist_fit/ricelike.m  pass    9/9   
  ..re/octave/api-v58/packages/statistics-1.7.4/dist_fit/tlsfit.m  pass   12/12  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fit/tlslike.m  pass    7/7   
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fit/unidfit.m  pass   11/11  
  ..re/octave/api-v58/packages/statistics-1.7.4/dist_fit/unifit.m  pass   11/11  
  ..re/octave/api-v58/packages/statistics-1.7.4/dist_fit/wblfit.m  pass   13/13  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fit/wbllike.m  pass    9/9   
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/betacdf.m  pass   25/25  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/betainv.m  pass   20/20  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/betapdf.m  pass   21/21  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/betarnd.m  pass   40/40  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/binocdf.m  pass   29/29  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/binoinv.m  pass   23/23  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/binopdf.m  pass   39/39  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/binornd.m  pass   40/40  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/bisacdf.m  pass   23/23  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/bisainv.m  pass   20/20  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/bisapdf.m  pass   20/20  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/bisarnd.m  pass   33/33  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/burrcdf.m  pass   25/25  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/burrinv.m  pass   23/23  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/burrpdf.m  pass   23/23  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/burrrnd.m  pass   36/36  
  ..re/octave/api-v58/packages/statistics-1.7.4/dist_fun/bvncdf.m  pass    5/5   
  ..re/octave/api-v58/packages/statistics-1.7.4/dist_fun/bvtcdf.m  pass    2/2   
  ..octave/api-v58/packages/statistics-1.7.4/dist_fun/cauchycdf.m  pass   22/22  
  ..octave/api-v58/packages/statistics-1.7.4/dist_fun/cauchyinv.m  pass   20/20  
  ..octave/api-v58/packages/statistics-1.7.4/dist_fun/cauchypdf.m  pass   20/20  
  ..octave/api-v58/packages/statistics-1.7.4/dist_fun/cauchyrnd.m  pass   33/33  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/chi2cdf.m  pass   17/17  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/chi2inv.m  pass   14/14  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/chi2pdf.m  pass   13/13  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/chi2rnd.m  pass   27/27  
  ..octave/api-v58/packages/statistics-1.7.4/dist_fun/copulacdf.m  pass    5/5   
  ..octave/api-v58/packages/statistics-1.7.4/dist_fun/copulapdf.m  pass    4/4   
  ..octave/api-v58/packages/statistics-1.7.4/dist_fun/copularnd.m  pass    5/5   
  ..are/octave/api-v58/packages/statistics-1.7.4/dist_fun/evcdf.m  pass   24/24  
  ..are/octave/api-v58/packages/statistics-1.7.4/dist_fun/evinv.m  pass   22/22  
  ..are/octave/api-v58/packages/statistics-1.7.4/dist_fun/evpdf.m  pass    8/8   
  ..are/octave/api-v58/packages/statistics-1.7.4/dist_fun/evrnd.m  pass   33/33  
  ..re/octave/api-v58/packages/statistics-1.7.4/dist_fun/expcdf.m  pass   21/21  
  ..re/octave/api-v58/packages/statistics-1.7.4/dist_fun/expinv.m  pass   18/18  
  ..re/octave/api-v58/packages/statistics-1.7.4/dist_fun/exppdf.m  pass   11/11  
  ..re/octave/api-v58/packages/statistics-1.7.4/dist_fun/exprnd.m  pass   27/27  
  ..hare/octave/api-v58/packages/statistics-1.7.4/dist_fun/fcdf.m  pass   21/21  
  ..hare/octave/api-v58/packages/statistics-1.7.4/dist_fun/finv.m  pass   24/24  
  ..hare/octave/api-v58/packages/statistics-1.7.4/dist_fun/fpdf.m  pass   19/19  
  ..hare/octave/api-v58/packages/statistics-1.7.4/dist_fun/frnd.m  pass   33/33  
  ..re/octave/api-v58/packages/statistics-1.7.4/dist_fun/gamcdf.m  pass   30/30  
  ..re/octave/api-v58/packages/statistics-1.7.4/dist_fun/gaminv.m  pass   25/25  
  ..re/octave/api-v58/packages/statistics-1.7.4/dist_fun/gampdf.m  pass   18/18  
  ..re/octave/api-v58/packages/statistics-1.7.4/dist_fun/gamrnd.m  pass   33/33  
  ..re/octave/api-v58/packages/statistics-1.7.4/dist_fun/geocdf.m  pass   17/17  
  ..re/octave/api-v58/packages/statistics-1.7.4/dist_fun/geoinv.m  pass   13/13  
  ..re/octave/api-v58/packages/statistics-1.7.4/dist_fun/geopdf.m  pass   13/13  
  ..re/octave/api-v58/packages/statistics-1.7.4/dist_fun/geornd.m  pass   24/24  
  ..re/octave/api-v58/packages/statistics-1.7.4/dist_fun/gevcdf.m  pass   18/18  
  ..re/octave/api-v58/packages/statistics-1.7.4/dist_fun/gevinv.m  pass   15/15  
  ..re/octave/api-v58/packages/statistics-1.7.4/dist_fun/gevpdf.m  pass   15/15  
  ..re/octave/api-v58/packages/statistics-1.7.4/dist_fun/gevrnd.m  pass   34/34  
  ..are/octave/api-v58/packages/statistics-1.7.4/dist_fun/gpcdf.m  pass   76/76  
  ..are/octave/api-v58/packages/statistics-1.7.4/dist_fun/gpinv.m  pass   51/51  
  ..are/octave/api-v58/packages/statistics-1.7.4/dist_fun/gppdf.m  pass   51/51  
  ..are/octave/api-v58/packages/statistics-1.7.4/dist_fun/gprnd.m  pass   56/56  
  ..octave/api-v58/packages/statistics-1.7.4/dist_fun/gumbelcdf.m  pass   24/24  
  ..octave/api-v58/packages/statistics-1.7.4/dist_fun/gumbelinv.m  pass   23/23  
  ..octave/api-v58/packages/statistics-1.7.4/dist_fun/gumbelpdf.m  pass    8/8   
  ..octave/api-v58/packages/statistics-1.7.4/dist_fun/gumbelrnd.m  pass   33/33  
  ..are/octave/api-v58/packages/statistics-1.7.4/dist_fun/hncdf.m  pass   25/25  
  ..are/octave/api-v58/packages/statistics-1.7.4/dist_fun/hninv.m  pass   15/15  
  ..are/octave/api-v58/packages/statistics-1.7.4/dist_fun/hnpdf.m  pass   14/14  
  ..are/octave/api-v58/packages/statistics-1.7.4/dist_fun/hnrnd.m  pass   35/35  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/hygecdf.m  pass   32/32  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/hygeinv.m  pass   26/26  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/hygepdf.m  pass   25/25  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/hygernd.m  pass   36/36  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/invgcdf.m  pass   25/25  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/invginv.m  pass   15/15  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/invgpdf.m  pass   14/14  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/invgrnd.m  pass   35/35  
  ../octave/api-v58/packages/statistics-1.7.4/dist_fun/iwishpdf.m  pass    6/6   
  ../octave/api-v58/packages/statistics-1.7.4/dist_fun/iwishrnd.m  pass    8/8   
  ..re/octave/api-v58/packages/statistics-1.7.4/dist_fun/jsucdf.m  pass    3/3   
  ..re/octave/api-v58/packages/statistics-1.7.4/dist_fun/jsupdf.m  pass    3/3   
  ..ctave/api-v58/packages/statistics-1.7.4/dist_fun/laplacecdf.m  pass   17/17  
  ..ctave/api-v58/packages/statistics-1.7.4/dist_fun/laplaceinv.m  pass   16/16  
  ..ctave/api-v58/packages/statistics-1.7.4/dist_fun/laplacepdf.m  pass   15/15  
  ..ctave/api-v58/packages/statistics-1.7.4/dist_fun/laplacernd.m  pass   33/33  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/logicdf.m  pass   16/16  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/logiinv.m  pass   16/16  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/logipdf.m  pass   14/14  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/logirnd.m  pass   33/33  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/loglcdf.m  pass   25/25  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/loglinv.m  pass   14/14  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/loglpdf.m  pass   14/14  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/loglrnd.m  pass   33/33  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/logncdf.m  pass   24/24  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/logninv.m  pass   18/18  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/lognpdf.m  pass   17/17  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/lognrnd.m  pass   33/33  
  ..are/octave/api-v58/packages/statistics-1.7.4/dist_fun/mnpdf.m  pass    2/2   
  ..are/octave/api-v58/packages/statistics-1.7.4/dist_fun/mnrnd.m  pass    3/3   
  ..re/octave/api-v58/packages/statistics-1.7.4/dist_fun/mvncdf.m  pass   12/12  
  ..re/octave/api-v58/packages/statistics-1.7.4/dist_fun/mvnpdf.m  pass    9/9   
  ..re/octave/api-v58/packages/statistics-1.7.4/dist_fun/mvnrnd.m  pass    6/6   
  ..re/octave/api-v58/packages/statistics-1.7.4/dist_fun/mvtcdf.m  pass   10/10  
  ..octave/api-v58/packages/statistics-1.7.4/dist_fun/mvtcdfqmc.m  pass    2/2   
  ..re/octave/api-v58/packages/statistics-1.7.4/dist_fun/mvtpdf.m  pass    3/3   
  ..re/octave/api-v58/packages/statistics-1.7.4/dist_fun/mvtrnd.m  pass    2/2   
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/nakacdf.m  pass   19/19  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/nakainv.m  pass   17/17  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/nakapdf.m  pass   17/17  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/nakarnd.m  pass   33/33  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/nbincdf.m  pass   22/22  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/nbininv.m  pass   23/23  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/nbinpdf.m  pass   18/18  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/nbinrnd.m  pass   33/33  
  ..re/octave/api-v58/packages/statistics-1.7.4/dist_fun/ncfcdf.m  pass   19/19  
  ..re/octave/api-v58/packages/statistics-1.7.4/dist_fun/ncfinv.m  pass   19/19  
  ..re/octave/api-v58/packages/statistics-1.7.4/dist_fun/ncfpdf.m  pass   19/19  
  ..re/octave/api-v58/packages/statistics-1.7.4/dist_fun/ncfrnd.m  pass   38/38  
  ..re/octave/api-v58/packages/statistics-1.7.4/dist_fun/nctcdf.m  pass   16/16  
  ..re/octave/api-v58/packages/statistics-1.7.4/dist_fun/nctinv.m  pass   16/16  
  ..re/octave/api-v58/packages/statistics-1.7.4/dist_fun/nctpdf.m  pass   16/16  
  ..re/octave/api-v58/packages/statistics-1.7.4/dist_fun/nctrnd.m  pass   33/33  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/ncx2cdf.m  pass   16/16  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/ncx2inv.m  pass   16/16  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/ncx2pdf.m  pass   16/16  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/ncx2rnd.m  pass   33/33  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/normcdf.m  pass   24/24  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/norminv.m  pass   19/19  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/normpdf.m  pass   16/16  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/normrnd.m  pass   33/33  
  ..are/octave/api-v58/packages/statistics-1.7.4/dist_fun/plcdf.m  pass   17/17  
  ..are/octave/api-v58/packages/statistics-1.7.4/dist_fun/plinv.m  pass   14/14  
  ..are/octave/api-v58/packages/statistics-1.7.4/dist_fun/plpdf.m  pass   15/15  
  ..are/octave/api-v58/packages/statistics-1.7.4/dist_fun/plrnd.m  pass   26/26  
  ../octave/api-v58/packages/statistics-1.7.4/dist_fun/poisscdf.m  pass   15/15  
  ../octave/api-v58/packages/statistics-1.7.4/dist_fun/poissinv.m  pass   13/13  
  ../octave/api-v58/packages/statistics-1.7.4/dist_fun/poisspdf.m  pass   12/12  
  ../octave/api-v58/packages/statistics-1.7.4/dist_fun/poissrnd.m  pass   29/29  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/raylcdf.m  pass   12/12  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/raylinv.m  pass    8/8   
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/raylpdf.m  pass    8/8   
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/raylrnd.m  pass   29/29  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/ricecdf.m  pass   17/17  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/riceinv.m  pass   20/20  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/ricepdf.m  pass   19/19  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/ricernd.m  pass   40/40  
  ..hare/octave/api-v58/packages/statistics-1.7.4/dist_fun/tcdf.m  pass   30/30  
  ..hare/octave/api-v58/packages/statistics-1.7.4/dist_fun/tinv.m  pass   13/13  
  ..re/octave/api-v58/packages/statistics-1.7.4/dist_fun/tlscdf.m  pass   27/27  
  ..re/octave/api-v58/packages/statistics-1.7.4/dist_fun/tlsinv.m  pass   20/20  
  ..re/octave/api-v58/packages/statistics-1.7.4/dist_fun/tlspdf.m  pass   21/21  
  ..re/octave/api-v58/packages/statistics-1.7.4/dist_fun/tlsrnd.m  pass   42/42  
  ..hare/octave/api-v58/packages/statistics-1.7.4/dist_fun/tpdf.m  pass   14/14  
  ..re/octave/api-v58/packages/statistics-1.7.4/dist_fun/tricdf.m  pass   29/29  
  ..re/octave/api-v58/packages/statistics-1.7.4/dist_fun/triinv.m  pass   26/26  
  ..re/octave/api-v58/packages/statistics-1.7.4/dist_fun/tripdf.m  pass   26/26  
  ..re/octave/api-v58/packages/statistics-1.7.4/dist_fun/trirnd.m  pass   36/36  
  ..hare/octave/api-v58/packages/statistics-1.7.4/dist_fun/trnd.m  pass   29/29  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/unidcdf.m  pass   17/17  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/unidinv.m  pass   13/13  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/unidpdf.m  pass   12/12  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/unidrnd.m  pass   29/29  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/unifcdf.m  pass   27/27  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/unifinv.m  pass   19/19  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/unifpdf.m  pass   19/19  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/unifrnd.m  pass   33/33  
  ..are/octave/api-v58/packages/statistics-1.7.4/dist_fun/vmcdf.m  pass   20/20  
  ..are/octave/api-v58/packages/statistics-1.7.4/dist_fun/vminv.m  pass   12/12  
  ..are/octave/api-v58/packages/statistics-1.7.4/dist_fun/vmpdf.m  pass   15/15  
  ..are/octave/api-v58/packages/statistics-1.7.4/dist_fun/vmrnd.m  pass   33/33  
  ..re/octave/api-v58/packages/statistics-1.7.4/dist_fun/wblcdf.m  pass   28/28  
  ..re/octave/api-v58/packages/statistics-1.7.4/dist_fun/wblinv.m  pass   18/18  
  ..re/octave/api-v58/packages/statistics-1.7.4/dist_fun/wblpdf.m  pass   17/17  
  ..re/octave/api-v58/packages/statistics-1.7.4/dist_fun/wblrnd.m  pass   33/33  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/wienrnd.m  pass    5/5   
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/wishpdf.m  pass    7/7   
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_fun/wishrnd.m  pass    9/9   
  ..api-v58/packages/statistics-1.7.4/dist_obj/BetaDistribution.m  pass   96/96  
  ..v58/packages/statistics-1.7.4/dist_obj/BinomialDistribution.m  pass  102/102 
  ..ages/statistics-1.7.4/dist_obj/BirnbaumSaundersDistribution.m  pass   96/96  
  ..api-v58/packages/statistics-1.7.4/dist_obj/BurrDistribution.m  pass  104/104 
  ../packages/statistics-1.7.4/dist_obj/ExponentialDistribution.m  pass   90/90  
  ..packages/statistics-1.7.4/dist_obj/ExtremeValueDistribution.m  pass   95/95  
  ..pi-v58/packages/statistics-1.7.4/dist_obj/GammaDistribution.m  pass   96/96  
  ..atistics-1.7.4/dist_obj/GeneralizedExtremeValueDistribution.m  pass  100/100 
  ..ges/statistics-1.7.4/dist_obj/GeneralizedParetoDistribution.m  pass  100/100 
  ..8/packages/statistics-1.7.4/dist_obj/HalfNormalDistribution.m  pass   96/96  
  ..kages/statistics-1.7.4/dist_obj/InverseGaussianDistribution.m  pass   96/96  
  ..v58/packages/statistics-1.7.4/dist_obj/LogisticDistribution.m  pass   95/95  
  ../packages/statistics-1.7.4/dist_obj/LoglogisticDistribution.m  pass   95/95  
  ..58/packages/statistics-1.7.4/dist_obj/LognormalDistribution.m  pass   95/95  
  ..8/packages/statistics-1.7.4/dist_obj/LoguniformDistribution.m  pass   65/65  
  ../packages/statistics-1.7.4/dist_obj/MultinomialDistribution.m  pass   64/64  
  ..v58/packages/statistics-1.7.4/dist_obj/NakagamiDistribution.m  pass   95/95  
  ..ages/statistics-1.7.4/dist_obj/NegativeBinomialDistribution.m  pass  102/102 
  ..i-v58/packages/statistics-1.7.4/dist_obj/NormalDistribution.m  pass   95/95  
  ..kages/statistics-1.7.4/dist_obj/PiecewiseLinearDistribution.m  pass   63/63  
  ..-v58/packages/statistics-1.7.4/dist_obj/PoissonDistribution.m  pass   97/97  
  ..v58/packages/statistics-1.7.4/dist_obj/RayleighDistribution.m  pass   90/90  
  ..i-v58/packages/statistics-1.7.4/dist_obj/RicianDistribution.m  pass   97/97  
  ..8/packages/statistics-1.7.4/dist_obj/TriangularDistribution.m  pass   69/69  
  ..-v58/packages/statistics-1.7.4/dist_obj/UniformDistribution.m  pass   63/63  
  ..-v58/packages/statistics-1.7.4/dist_obj/WeibullDistribution.m  pass   97/97  
  ..ckages/statistics-1.7.4/dist_obj/tLocationScaleDistribution.m  pass  102/102 
  ..octave/api-v58/packages/statistics-1.7.4/dist_stat/betastat.m  pass   15/15  
  ..octave/api-v58/packages/statistics-1.7.4/dist_stat/binostat.m  pass   15/15  
  ..octave/api-v58/packages/statistics-1.7.4/dist_stat/bisastat.m  pass   10/10  
  ..octave/api-v58/packages/statistics-1.7.4/dist_stat/burrstat.m  pass   15/15  
  ..octave/api-v58/packages/statistics-1.7.4/dist_stat/chi2stat.m  pass    5/5   
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_stat/evstat.m  pass   11/11  
  ../octave/api-v58/packages/statistics-1.7.4/dist_stat/expstat.m  pass    5/5   
  ..re/octave/api-v58/packages/statistics-1.7.4/dist_stat/fstat.m  pass   10/10  
  ../octave/api-v58/packages/statistics-1.7.4/dist_stat/gamstat.m  pass   10/10  
  ../octave/api-v58/packages/statistics-1.7.4/dist_stat/geostat.m  pass    5/5   
  ../octave/api-v58/packages/statistics-1.7.4/dist_stat/gevstat.m  pass   13/13  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_stat/gpstat.m  pass   19/19  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_stat/hnstat.m  pass   14/14  
  ..octave/api-v58/packages/statistics-1.7.4/dist_stat/hygestat.m  pass   14/14  
  ..octave/api-v58/packages/statistics-1.7.4/dist_stat/invgstat.m  pass   13/13  
  ..octave/api-v58/packages/statistics-1.7.4/dist_stat/logistat.m  pass   13/13  
  ..octave/api-v58/packages/statistics-1.7.4/dist_stat/loglstat.m  pass   13/13  
  ..octave/api-v58/packages/statistics-1.7.4/dist_stat/lognstat.m  pass   10/10  
  ..octave/api-v58/packages/statistics-1.7.4/dist_stat/nakastat.m  pass   11/11  
  ..octave/api-v58/packages/statistics-1.7.4/dist_stat/nbinstat.m  pass   10/10  
  ../octave/api-v58/packages/statistics-1.7.4/dist_stat/ncfstat.m  pass   20/20  
  ../octave/api-v58/packages/statistics-1.7.4/dist_stat/nctstat.m  pass   16/16  
  ..octave/api-v58/packages/statistics-1.7.4/dist_stat/ncx2stat.m  pass   16/16  
  ..octave/api-v58/packages/statistics-1.7.4/dist_stat/normstat.m  pass   10/10  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_stat/plstat.m  pass   10/10  
  ..octave/api-v58/packages/statistics-1.7.4/dist_stat/poisstat.m  pass    5/5   
  ..octave/api-v58/packages/statistics-1.7.4/dist_stat/raylstat.m  pass    5/5   
  ..octave/api-v58/packages/statistics-1.7.4/dist_stat/ricestat.m  pass   16/16  
  ../octave/api-v58/packages/statistics-1.7.4/dist_stat/tlsstat.m  pass   28/28  
  ../octave/api-v58/packages/statistics-1.7.4/dist_stat/tristat.m  pass   10/10  
  ..re/octave/api-v58/packages/statistics-1.7.4/dist_stat/tstat.m  pass    5/5   
  ..octave/api-v58/packages/statistics-1.7.4/dist_stat/unidstat.m  pass    5/5   
  ..octave/api-v58/packages/statistics-1.7.4/dist_stat/unifstat.m  pass   10/10  
  ../octave/api-v58/packages/statistics-1.7.4/dist_stat/wblstat.m  pass   10/10  
  ..hare/octave/api-v58/packages/statistics-1.7.4/dist_wrap/cdf.m  pass   86/86  
  ../octave/api-v58/packages/statistics-1.7.4/dist_wrap/fitdist.m  pass   77/77  
  ..are/octave/api-v58/packages/statistics-1.7.4/dist_wrap/icdf.m  pass   86/86  
  ..octave/api-v58/packages/statistics-1.7.4/dist_wrap/makedist.m  pass  131/131 
  ..hare/octave/api-v58/packages/statistics-1.7.4/dist_wrap/mle.m  pass   36/36  
  ..hare/octave/api-v58/packages/statistics-1.7.4/dist_wrap/pdf.m  pass   86/86  
  ..e/octave/api-v58/packages/statistics-1.7.4/dist_wrap/random.m  pass   87/87  
  ../share/octave/api-v58/packages/statistics-1.7.4/shadow9/mad.m  pass  128/128 
  ..share/octave/api-v58/packages/statistics-1.7.4/shadow9/mean.m  pass   79/80  
                                                    (reported bug) XFAIL   1
  ..are/octave/api-v58/packages/statistics-1.7.4/shadow9/median.m  pass  159/159 
  ../share/octave/api-v58/packages/statistics-1.7.4/shadow9/std.m  pass  162/162 
  ../share/octave/api-v58/packages/statistics-1.7.4/shadow9/var.m  pass  162/162 
  ..tistics-1.7.4/x86_64-pc-linux-gnu-api-v58/editDistance.cc-tst  pass   33/33  
  ..atistics-1.7.4/x86_64-pc-linux-gnu-api-v58/fcnnpredict.cc-tst  pass   20/20  
  ..statistics-1.7.4/x86_64-pc-linux-gnu-api-v58/fcnntrain.cc-tst  pass   33/33  
  ..tatistics-1.7.4/x86_64-pc-linux-gnu-api-v58/libsvmread.cc-tst  pass    4/4   
  ..atistics-1.7.4/x86_64-pc-linux-gnu-api-v58/libsvmwrite.cc-tst  pass    7/7   
  ..tatistics-1.7.4/x86_64-pc-linux-gnu-api-v58/svmpredict.cc-tst  pass    5/5   
  ../statistics-1.7.4/x86_64-pc-linux-gnu-api-v58/svmtrain.cc-tst  pass    4/4   
  ..octave/api-v58/packages/statistics-1.7.4/ExhaustiveSearcher.m  pass   14/14  
  ..local/share/octave/api-v58/packages/statistics-1.7.4/adtest.m  pass   25/25  
  ..local/share/octave/api-v58/packages/statistics-1.7.4/anova1.m  pass    2/2   
  ..local/share/octave/api-v58/packages/statistics-1.7.4/anova2.m  pass    3/3   
  ..local/share/octave/api-v58/packages/statistics-1.7.4/anovan.m  pass   12/12  
  ../.local/share/octave/api-v58/packages/statistics-1.7.4/bar3.m  pass   20/20  
  ...local/share/octave/api-v58/packages/statistics-1.7.4/bar3h.m  pass   20/20  
  ..hare/octave/api-v58/packages/statistics-1.7.4/bartlett_test.m  pass   16/16  
  ..cal/share/octave/api-v58/packages/statistics-1.7.4/barttest.m  pass   10/10  
  ..cal/share/octave/api-v58/packages/statistics-1.7.4/binotest.m  pass    1/1   
  ..ocal/share/octave/api-v58/packages/statistics-1.7.4/boxplot.m  pass   34/34  
  ..al/share/octave/api-v58/packages/statistics-1.7.4/canoncorr.m  pass    8/8   
  ..ocal/share/octave/api-v58/packages/statistics-1.7.4/cdfcalc.m  pass    5/5   
  ..ocal/share/octave/api-v58/packages/statistics-1.7.4/cdfplot.m  pass    5/5   
  ..ocal/share/octave/api-v58/packages/statistics-1.7.4/chi2gof.m  pass   11/11  
  ..cal/share/octave/api-v58/packages/statistics-1.7.4/chi2test.m  pass   34/34  
  ..ocal/share/octave/api-v58/packages/statistics-1.7.4/cholcov.m  pass    1/1
  ../share/octave/api-v58/packages/statistics-1.7.4/cl_multinom.m  pass    4/4   
  ..ocal/share/octave/api-v58/packages/statistics-1.7.4/cluster.m  pass    6/6   
  ../share/octave/api-v58/packages/statistics-1.7.4/clusterdata.m  pass    4/4
  ..cal/share/octave/api-v58/packages/statistics-1.7.4/cmdscale.m  pass    2/2   
  ..local/share/octave/api-v58/packages/statistics-1.7.4/combnk.m  pass    4/4   
  ..are/octave/api-v58/packages/statistics-1.7.4/confusionchart.m  pass   18/18  
  ..share/octave/api-v58/packages/statistics-1.7.4/confusionmat.m  pass    1/1   
  ..cal/share/octave/api-v58/packages/statistics-1.7.4/cophenet.m  pass    5/5   
  ..e/octave/api-v58/packages/statistics-1.7.4/correlation_test.m  pass   20/20  
  ..cal/share/octave/api-v58/packages/statistics-1.7.4/crosstab.m  pass    8/8   
  ..cal/share/octave/api-v58/packages/statistics-1.7.4/crossval.m  pass    1/1   
  ..l/share/octave/api-v58/packages/statistics-1.7.4/datasample.m  pass   17/17  
  ../.local/share/octave/api-v58/packages/statistics-1.7.4/dcov.m  pass    1/1   
  ..l/share/octave/api-v58/packages/statistics-1.7.4/dendrogram.m  pass    9/9   
  ../.local/share/octave/api-v58/packages/statistics-1.7.4/ecdf.m  pass   14/14  
  ..cal/share/octave/api-v58/packages/statistics-1.7.4/einstein.m  pass    6/6   
  ..share/octave/api-v58/packages/statistics-1.7.4/evalclusters.m  pass   22/22  
  ../.local/share/octave/api-v58/packages/statistics-1.7.4/ff2n.m  pass   10/10  
  ../share/octave/api-v58/packages/statistics-1.7.4/fillmissing.m  pass  379/380 
                                                    (reported bug) XFAIL   1
  ..l/share/octave/api-v58/packages/statistics-1.7.4/fishertest.m  pass   19/19  
  ..al/share/octave/api-v58/packages/statistics-1.7.4/fitcdiscr.m  pass    6/6   
  ..ocal/share/octave/api-v58/packages/statistics-1.7.4/fitcgam.m  pass    8/8   
  ..ocal/share/octave/api-v58/packages/statistics-1.7.4/fitcknn.m  pass   29/29  
  ..ocal/share/octave/api-v58/packages/statistics-1.7.4/fitcnet.m  pass    6/6   
  ..ocal/share/octave/api-v58/packages/statistics-1.7.4/fitcsvm.m  pass   14/14  
  ..al/share/octave/api-v58/packages/statistics-1.7.4/fitgmdist.m  pass    1/1   
  ...local/share/octave/api-v58/packages/statistics-1.7.4/fitlm.m  pass    3/3   
  ..ocal/share/octave/api-v58/packages/statistics-1.7.4/fitrgam.m  pass    7/7   
  ..cal/share/octave/api-v58/packages/statistics-1.7.4/friedman.m  pass    2/2   
  ..cal/share/octave/api-v58/packages/statistics-1.7.4/fullfact.m  pass   15/15  
  ..ocal/share/octave/api-v58/packages/statistics-1.7.4/geomean.m  pass    8/8   
  ..local/share/octave/api-v58/packages/statistics-1.7.4/glmfit.m  pass   70/70  
  ..local/share/octave/api-v58/packages/statistics-1.7.4/glmval.m  pass   57/57  
  ..are/octave/api-v58/packages/statistics-1.7.4/gmdistribution.m  pass    1/1   
  ..ocal/share/octave/api-v58/packages/statistics-1.7.4/grp2idx.m  pass   10/10  
  ..cal/share/octave/api-v58/packages/statistics-1.7.4/grpstats.m  pass    4/4   
  ..cal/share/octave/api-v58/packages/statistics-1.7.4/gscatter.m  pass    9/9   
  ..cal/share/octave/api-v58/packages/statistics-1.7.4/harmmean.m  pass    8/8   
  ...local/share/octave/api-v58/packages/statistics-1.7.4/hist3.m  pass   16/16  
  ..ocal/share/octave/api-v58/packages/statistics-1.7.4/histfit.m  pass   17/17  
  ../share/octave/api-v58/packages/statistics-1.7.4/hmmestimate.m  pass    3/3   
  ../share/octave/api-v58/packages/statistics-1.7.4/hmmgenerate.m  pass    2/2   
  ..l/share/octave/api-v58/packages/statistics-1.7.4/hmmviterbi.m  pass    2/2   
  ..e/octave/api-v58/packages/statistics-1.7.4/hotelling_t2test.m  pass   13/13  
  ../octave/api-v58/packages/statistics-1.7.4/hotelling_t2test2.m  pass   14/14  
  ..share/octave/api-v58/packages/statistics-1.7.4/inconsistent.m  pass    8/8   
  ..al/share/octave/api-v58/packages/statistics-1.7.4/ismissing.m  pass   49/49  
  ..al/share/octave/api-v58/packages/statistics-1.7.4/isoutlier.m  pass   59/59  
  ..al/share/octave/api-v58/packages/statistics-1.7.4/jackknife.m  pass    1/1   
  ..local/share/octave/api-v58/packages/statistics-1.7.4/kmeans.m  pass   31/31  
  ..al/share/octave/api-v58/packages/statistics-1.7.4/knnsearch.m  pass   42/42  
  ..hare/octave/api-v58/packages/statistics-1.7.4/kruskalwallis.m  pass    1/1   
  ..local/share/octave/api-v58/packages/statistics-1.7.4/kstest.m  pass   21/21  
  ..ocal/share/octave/api-v58/packages/statistics-1.7.4/kstest2.m  pass   14/14  
  ../share/octave/api-v58/packages/statistics-1.7.4/levene_test.m  pass   20/20  
  ..ocal/share/octave/api-v58/packages/statistics-1.7.4/linkage.m  pass   12/12  
  ..al/share/octave/api-v58/packages/statistics-1.7.4/loadmodel.m  pass    4/4   
  ..ctave/api-v58/packages/statistics-1.7.4/logistic_regression.m  pass    2/2   
  ...local/share/octave/api-v58/packages/statistics-1.7.4/logit.m  pass    4/4   
  ...local/share/octave/api-v58/packages/statistics-1.7.4/mahal.m  pass    9/9   
  ..ocal/share/octave/api-v58/packages/statistics-1.7.4/manova1.m  pass    2/2   
  ..hare/octave/api-v58/packages/statistics-1.7.4/manovacluster.m  pass    2/2   
  ..share/octave/api-v58/packages/statistics-1.7.4/mcnemar_test.m  pass   17/17  
  ..cal/share/octave/api-v58/packages/statistics-1.7.4/mhsample.m  pass    6/6   
  ..local/share/octave/api-v58/packages/statistics-1.7.4/mnrfit.m  pass   13/13  
  ..re/octave/api-v58/packages/statistics-1.7.4/monotone_smooth.m  pass   10/10  
  ../share/octave/api-v58/packages/statistics-1.7.4/multcompare.m  pass    8/8   
  ..local/share/octave/api-v58/packages/statistics-1.7.4/nanmax.m  pass   24/24  
  ..local/share/octave/api-v58/packages/statistics-1.7.4/nanmin.m  pass   24/24  
  ..local/share/octave/api-v58/packages/statistics-1.7.4/nansum.m  pass    9/9   
  ..ve/api-v58/packages/statistics-1.7.4/normalise_distribution.m  pass   14/14  
  ..cal/share/octave/api-v58/packages/statistics-1.7.4/normplot.m  pass    6/6   
  ..e/octave/api-v58/packages/statistics-1.7.4/optimalleaforder.m  pass    7/7   
  ..h/.local/share/octave/api-v58/packages/statistics-1.7.4/pca.m  pass   31/32  
                                                (expected failure) XFAIL   1
  ..local/share/octave/api-v58/packages/statistics-1.7.4/pcacov.m  pass    3/3   
  ..local/share/octave/api-v58/packages/statistics-1.7.4/pcares.m  pass    3/3   
  ...local/share/octave/api-v58/packages/statistics-1.7.4/pdist.m  pass   29/29  
  ..local/share/octave/api-v58/packages/statistics-1.7.4/pdist2.m  pass   33/33  
  ..l/share/octave/api-v58/packages/statistics-1.7.4/plsregress.m  pass   24/24  
  ..local/share/octave/api-v58/packages/statistics-1.7.4/ppplot.m  pass    5/5   
  ..cal/share/octave/api-v58/packages/statistics-1.7.4/princomp.m  pass   19/19  
  ..local/share/octave/api-v58/packages/statistics-1.7.4/probit.m  pass    4/4   
  ..l/share/octave/api-v58/packages/statistics-1.7.4/procrustes.m  pass   15/15  
  ..local/share/octave/api-v58/packages/statistics-1.7.4/qqplot.m  pass    6/6   
  ..local/share/octave/api-v58/packages/statistics-1.7.4/qrandn.m  pass    6/6   
  ..l/share/octave/api-v58/packages/statistics-1.7.4/randsample.m  pass    1/1   
  ../share/octave/api-v58/packages/statistics-1.7.4/rangesearch.m  pass   31/31  
  ..ocal/share/octave/api-v58/packages/statistics-1.7.4/ranksum.m  pass    2/2   
  ..ocal/share/octave/api-v58/packages/statistics-1.7.4/regress.m  pass    1/1   
  ..l/share/octave/api-v58/packages/statistics-1.7.4/regress_gp.m  pass   22/22  
  ..e/octave/api-v58/packages/statistics-1.7.4/regression_ftest.m  pass   18/18  
  ..e/octave/api-v58/packages/statistics-1.7.4/regression_ttest.m  pass   16/16  
  ...local/share/octave/api-v58/packages/statistics-1.7.4/ridge.m  pass   17/17  
  ..al/share/octave/api-v58/packages/statistics-1.7.4/rmmissing.m  pass   31/31  
  ..cal/share/octave/api-v58/packages/statistics-1.7.4/runstest.m  pass   14/14  
  ../share/octave/api-v58/packages/statistics-1.7.4/sampsizepwr.m  pass   68/68  
  ..al/share/octave/api-v58/packages/statistics-1.7.4/sigma_pts.m  pass    7/7   
  ..cal/share/octave/api-v58/packages/statistics-1.7.4/signrank.m  pass   22/22  
  ..cal/share/octave/api-v58/packages/statistics-1.7.4/signtest.m  pass   20/20  
  ..l/share/octave/api-v58/packages/statistics-1.7.4/silhouette.m  pass    4/4   
  ../share/octave/api-v58/packages/statistics-1.7.4/slicesample.m  pass    4/4   
  ..l/share/octave/api-v58/packages/statistics-1.7.4/squareform.m  pass    9/9   
  ..octave/api-v58/packages/statistics-1.7.4/standardizeMissing.m  pass   49/49  
  ../share/octave/api-v58/packages/statistics-1.7.4/stepwisefit.m  pass    1/1   
  ..cal/share/octave/api-v58/packages/statistics-1.7.4/tabulate.m  pass    5/5   
  ..cal/share/octave/api-v58/packages/statistics-1.7.4/tiedrank.m  pass   12/12  
  ..cal/share/octave/api-v58/packages/statistics-1.7.4/trimmean.m  pass   26/26  
  ...local/share/octave/api-v58/packages/statistics-1.7.4/ttest.m  pass    3/3   
  ..local/share/octave/api-v58/packages/statistics-1.7.4/ttest2.m  pass    3/3   
  ..ocal/share/octave/api-v58/packages/statistics-1.7.4/vartest.m  pass   12/12  
  ..cal/share/octave/api-v58/packages/statistics-1.7.4/vartest2.m  pass   14/14  
  ..cal/share/octave/api-v58/packages/statistics-1.7.4/vartestn.m  pass   17/17  
  ..local/share/octave/api-v58/packages/statistics-1.7.4/violin.m  pass    5/5   
  ..ocal/share/octave/api-v58/packages/statistics-1.7.4/wblplot.m  pass    1/1   
  ../.local/share/octave/api-v58/packages/statistics-1.7.4/x2fx.m  pass    5/5   
  ...local/share/octave/api-v58/packages/statistics-1.7.4/ztest.m  pass   13/13  
  ..local/share/octave/api-v58/packages/statistics-1.7.4/ztest2.m  pass   11/11  

Fixed test scripts:


Failure Summary:

  ..share/octave/api-v58/packages/statistics-1.7.4/shadow9/mean.m  pass   79/80  
                                                    (reported bug) XFAIL   1
  ../share/octave/api-v58/packages/statistics-1.7.4/fillmissing.m  pass  379/380
                                                    (reported bug) XFAIL   1
  ..h/.local/share/octave/api-v58/packages/statistics-1.7.4/pca.m  pass   31/32
                                                (expected failure) XFAIL   1

Summary:

  PASS                            11305
  FAIL                                0
  XFAIL (reported bug)                2
  XFAIL (expected failure)            1

See the file /mnt/c/Users/admin/Desktop/statistics/fntests.log for additional details.

XFAIL items are known bugs or expected failures.
Bug report numbers may be found in the log file:
/mnt/c/Users/admin/Desktop/statistics/fntests.log
Please help improve Octave by contributing fixes for them.

0 (of 454) .m files have no tests.

Please help improve Octave by contributing tests for these files
(see the list in the file /mnt/c/Users/admin/Desktop/statistics/fntests.log).

``` 

</details> 