### PR TITLE
Fix warnings during installation of statistics

### DIFF
--- a/inst/dist_wrap/fitdist.m
+++ b/inst/dist_wrap/fitdist.m
@@ -18,10 +18,8 @@
 ## -*- texinfo -*-
 ## @deftypefn  {statistics} {@var{pd} =} fitdist (@var{x}, @var{distname})
 ## @deftypefnx {statistics} {@var{pd} =} fitdist (@var{x}, @var{distname}, @var{Name}, @var{Value})
-## @deftypefnx {statistics} {[@var{pdca}, @var{gn}, @var{gl}] =} fitdist @
-## (@var{x}, @var{distname}, @qcode{"By"}, @var{groupvar})
-## @deftypefnx {statistics} {[@var{pdca}, @var{gn}, @var{gl}] =} fitdist @
-## (@var{x}, @var{distname}, @qcode{"By"}, @var{groupvar}, @var{Name}, @var{Value})
+## @deftypefnx {statistics} {[@var{pdca}, @var{gn}, @var{gl}] =} fitdist (@var{x}, @var{distname}, @qcode{"By"}, @var{groupvar})
+## @deftypefnx {statistics} {[@var{pdca}, @var{gn}, @var{gl}] =} fitdist (@var{x}, @var{distname}, @qcode{"By"}, @var{groupvar}, @var{Name}, @var{Value})
 ##
 ## Create probability distribution object.
 ##


### PR DESCRIPTION
This PR removes the warnings that appear with octave 11.0.0 & makeinfo 7.1,
while installing statistics.

Opened as discussed with @pr0m1th3as