### PR TITLE
Fix test failure in `ClassificationGAM`

### DIFF
--- a/inst/Classification/ClassificationGAM.m
+++ b/inst/Classification/ClassificationGAM.m
@@ -1187,7 +1187,7 @@ endfunction
 %! CVMdl = crossval (obj, "KFold", 3);
 %! assert (class (CVMdl), "ClassificationPartitionedModel")
 %! assert ({CVMdl.X, CVMdl.Y}, {x, y})
-%! assert (CVMdl.KFold == 4)
+%! assert (CVMdl.KFold == 3)
 %! assert (class (CVMdl.Trained{1}), "CompactClassificationGAM")
 %! assert (CVMdl.CrossValidatedModel, "ClassificationGAM")
 %!test


### PR DESCRIPTION
Are we okay with these warnings, I assume they are intentional due to `crossval` randomness?

```matlab
octave:6> test ./inst/Classification/ClassificationGAM.m
warning: One or more of the unique class values in the stratification variable is not present in one or more folds.
warning: called from
    cvpartition at line 764 column 19
    crossval at line 792 column 9
    __test__ at line 3 column 2
    test at line 685 column 11

warning: One or more of the unique class values in the stratification variable is not present in one or more folds.
warning: called from
    cvpartition at line 764 column 19
    __test__ at line 3 column 2
    test at line 685 column 11

PASSES 35 out of 35 tests
```