### PR TITLE
Fix `pca.m`

### DIFF
--- a/inst/pca.m
+++ b/inst/pca.m
@@ -525,6 +525,90 @@ endfunction
 %!test assert(tsquare, [1.5; 0.5; 1.5], 10*eps);
 
 %!test
+%! x = [1,2,3;2,1,3]';
+%! [COEFF, SCORE, latent, tsquare] = pca (x, "Economy", false, "weights", ...
+%!                                        [2 1 2], "variableweights", ...
+%!                                        "variance");
+%! COEFF_exp = [0.7906  0.7906; 0.6614 -0.6614];
+%! SCORE_exp = [-0.7836 -0.4813; -0.9071 0.9071; 1.2372 0.0277];
+%! latent_exp = [2.5562; 0.6438];
+%! tsquare_exp = [0.6000; 1.6000; 0.6000];
+%! assert (COEFF, COEFF_exp, 1e-4);
+%! assert (SCORE, SCORE_exp, 1e-4);
+%! assert (latent, latent_exp, 1e-4);
+%! assert (tsquare, tsquare_exp, 1e-4);
+
+%!test
+%! x = [1,2,3;2,1,3]';
+%! [COEFF, SCORE, latent, tsquare] = pca (x, "Economy", false, "weights", ...
+%!                                        [1 3 2], "variableweights", ...
+%!                                        "variance");
+%! COEFF_exp = [0.6216 -0.6216; 0.8118 0.8118];
+%! SCORE_exp = [-0.8358 1.0411; -0.6473 -0.3792; 1.3889 0.0482];
+%! latent_exp = [2.9067; 0.7599];
+%! tsquare_exp = [1.6667; 0.3333; 0.6667];
+%! assert (COEFF, COEFF_exp, 1e-4);
+%! assert (SCORE, SCORE_exp, 1e-4);
+%! assert (latent, latent_exp, 1e-4);
+%! assert (tsquare, tsquare_exp, 1e-4);
+
+%!test
+%! x = [1,2,3;2,1,3]';
+%! [COEFF, SCORE, latent, tsquare] = pca (x, "Economy", false, "weights", ...
+%!                                        [1 0.5 1.5], "variableweights", ...
+%!                                        "variance");
+%! COEFF_exp = [0.8118 0.8118; 0.6742 -0.6742];
+%! SCORE_exp = [-0.9657 -0.4713; -1.0915 0.8862; 1.0076 0.0188];
+%! latent_exp = [1.5257; 0.3077];
+%! tsquare_exp = [1.3333; 3.3333; 0.6667];
+%! assert (COEFF, COEFF_exp, 1e-4);
+%! assert (SCORE, SCORE_exp, 1e-4);
+%! assert (latent, latent_exp, 1e-4);
+%! assert (tsquare, tsquare_exp, 1e-4);
+
+%!test
+%! x = [1,2,3;2,1,3]';
+%! [COEFF, SCORE, latent, tsquare] = pca(x, "Economy", true, "weights", ...
+%!                                       [2 1 2], "variableweights", ...
+%!                                       "variance");
+%! COEFF_exp = [0.7906  0.7906; 0.6614 -0.6614];
+%! SCORE_exp = [-0.7836 -0.4813; -0.9071 0.9071; 1.2372 0.0277];
+%! latent_exp = [2.5562; 0.6438];
+%! tsquare_exp = [0.6000; 1.6000; 0.6000];
+%! assert (COEFF, COEFF_exp, 1e-4);
+%! assert (SCORE, SCORE_exp, 1e-4);
+%! assert (latent, latent_exp, 1e-4);
+%! assert (tsquare, tsquare_exp, 1e-4);
+
+%!test
+%! x = [1,2,3;2,1,3]';
+%! [COEFF, SCORE, latent, tsquare] = pca (x, "Economy", true, "weights", ...
+%!                                        [1 3 2], "variableweights", ...
+%!                                        "variance");
+%! COEFF_exp = [0.6216 -0.6216; 0.8118 0.8118];
+%! SCORE_exp = [-0.8358 1.0411; -0.6473 -0.3792; 1.3889 0.0482];
+%! latent_exp = [2.9067; 0.7599];
+%! tsquare_exp = [1.6667; 0.3333; 0.6667];
+%! assert (COEFF, COEFF_exp, 1e-4);
+%! assert (SCORE, SCORE_exp, 1e-4);
+%! assert (latent, latent_exp, 1e-4);
+%! assert (tsquare, tsquare_exp, 1e-4);
+
+%!test
+%! x = [1,2,3;2,1,3]';
+%! [COEFF, SCORE, latent, tsquare] = pca (x, "Economy", true, "weights", ...
+%!                                        [1 0.5 1.5], "variableweights", ...
+%!                                        "variance");
+%! COEFF_exp = [0.8118 0.8118; 0.6742 -0.6742];
+%! SCORE_exp = [-0.9657 -0.4713; -1.0915 0.8862; 1.0076 0.0188];
+%! latent_exp = [1.5257; 0.3077];
+%! tsquare_exp = [1.3333; 3.3333; 0.6667];
+%! assert (COEFF, COEFF_exp, 1e-4);
+%! assert (SCORE, SCORE_exp, 1e-4);
+%! assert (latent, latent_exp, 1e-4);
+%! assert (tsquare, tsquare_exp, 1e-4);
+
+%!test
 %! x=x';
 %! [COEFF,SCORE,latent,tsquare] = pca(x, "Economy", false);
 %! m=[sqrt(2),sqrt(2),0;-sqrt(2),sqrt(2),0;0,0,2]/2;


### PR DESCRIPTION
Fixes #279 

```
octave:13> [COEFF, SCORE, latent, tsquare] = pca (x, "Economy", false, "weights", [1 2 1], "variableweights", "variance")
COEFF =

   0.6325  -0.6325
   0.7416   0.7416

SCORE =

  -0.622019   0.959119
  -0.505650  -0.505650
   1.633319   0.052180

latent =

   1.7830
   0.7170

tsquare =

   1.5000
   0.5000
   1.5000
```