### PR TITLE
wishrnd fix

### DIFF
--- a/inst/dist_fun/wishrnd.m
+++ b/inst/dist_fun/wishrnd.m
@@ -66,7 +66,11 @@ function [W, D] = wishrnd (Sigma, df, D, n=1)
 
   p = size(D, 1);
 
-  if df < p
+  if df <= p - 1
+    if df != floor(df)
+      warning(["Undefined for non-integer df < p - 1;", ...
+              " truncating df to floor(df)"]);
+    endif
     df = floor(df); #distribution not defined for small noninteger df
     df_isint = 1;
   else


### PR DESCRIPTION
wishrnd takes a 'degrees of freedom' argument df.  When df is an integer, wishrnd generates what is essentially a sum of df semidefinite a rank one matrices.

When df is non-integral, the wishrnd uses a Bartlett decomposition, generating several normal variates along with chi2 variates with dof parameters

df, df - 1, ... , df - p + 1.

Where p is the dimension of the p x p scaling matrix Sigma.

Note that these are valid distributions as long as df > p - 1.  The original code conditioned on df >= p, so I am extending this condition to include fractional values p - 1 < df < p.

The current behavior of the function is to truncate df to floor(df) when the fractional df leads to an invalid distribution.  This behavior is preserved, but I am adding a warning so the user is informed that this is happening.