### PR TITLE
stepwisefit: initialize documented outputs to avoid undefined return errors

### DIFF
--- a/inst/stepwisefit.m
+++ b/inst/stepwisefit.m
@@ -1,5 +1,6 @@
 ## Copyright (C) 2013-2021 Nir Krakauer <nkrakauer@ccny.cuny.edu>
 ## Copyright (C) 2014 Mikael Kurula <mkurula@abo.fi>
+## Copyright (C) 2025 Jayant Chauhan <0001jayant@gmail.com>
 ##
 ## This file is part of the statistics package for GNU Octave.
 ##
@@ -56,6 +57,13 @@
 ## @end deftypefn
 
 function [X_use, b, bint, r, rint, stats] = stepwisefit(y, X, penter = 0.05, premove = 0.1, method = "corr")
+  % Phase-1.1: initialize all documented outputs to avoid undefined returns
+  X_use = [];
+  b     = [];
+  bint  = [];
+  r     = [];
+  rint  = [];
+  stats = struct ();
 
 if nargin >= 3 && isempty(penter)
   penter = 0.05;
@@ -197,4 +205,15 @@ endfunction
 %!   error ("Expected error not thrown");
 %! catch
 %!   assert (true);
+%! end_try_catch
+
+%!test
+%! % Phase-1.1: requesting all documented outputs must not crash
+%! y = randn (20, 1);
+%! X = randn (20, 3);
+%! try
+%!   [X_use, b, bint, r, rint, stats] = stepwisefit (y, X);
+%!   assert (isnumeric (X_use));
+%! catch
+%!   error ("stepwisefit crashed when requesting documented outputs");
 %! end_try_catch


### PR DESCRIPTION
This PR fixes an internal robustness issue in stepwisefit where requesting all documented outputs could crash with “undefined return list” errors.

earlier,
`[X_use, b, bint] = stepwisefit (y, X);` passed but `[X_use, b, bint, r, rint, stats] = stepwisefit (y, X);`failed .

after fix , 
tests passes as all documented outputs are now initialized defensively so that optional outputs exist even when not populated.

No changes are made to the public API, argument parsing, or algorithmic behavior.

A BIST is added to prevent regressions.