### PR TITLE
createns: avoid growing array when removing NSMethod arguments

### DIFF
--- a/inst/createns.m
+++ b/inst/createns.m
@@ -118,10 +118,7 @@ function obj = createns (X, varargin)
       error ("createns: 'NSMethod' must be a string.");
     endif
     NSMethod = lower (NSMethod);
-    remove_idx = [];
-    for i = idx
-      remove_idx = [remove_idx, 2*i-1, 2*i];
-    endfor
+    remove_idx = reshape ([2*idx-1; 2*idx], 1, []);
     varargin(remove_idx) = [];
   endif
 


### PR DESCRIPTION
This replaces loop-based construction of remove_idx with a vectorized expression to avoid repeated memory reallocations.
No functional change.