### PR TITLE
statistics/pca: clarify FIXME notes for missing-value and weighted std handling

### DIFF
--- a/inst/pca.m
+++ b/inst/pca.m
@@ -119,9 +119,13 @@
 ## @seealso{barttest, factoran, pcacov, pcares}
 ## @end deftypefn
 
-##FIXME
-## -- can change isnan to ismissing once the latter is implemented in Octave
-## -- change mystd to std and remove the helper function mystd once weighting is available in the Octave function
+## FIXME (compatibility notes):
+## - ismissing behaves like isnan for numeric arrays in recent Octave
+##   versions, but isnan is retained for backward compatibility.
+## - std(x, w) supports weighted standard deviation for vectors, but
+##   does not currently support NaN omission with weights for matrices.
+##   The mystd helper is therefore required for PCA variable scaling.
+
 
 function [coeff, score, latent, tsquared, explained, mu] = pca (x, varargin)
 


### PR DESCRIPTION
## Description

This PR clarifies existing `FIXME` notes in `pca.m` related to missing-value
handling and weighted standard deviation.

The current implementation relies on `isnan` and a custom `mystd` helper.
Although newer Octave/statistics versions provide `ismissing` and support
weighted standard deviation via `std`, there are still compatibility and API
limitations that make the current approach necessary.

This update documents those reasons explicitly to make the code easier to
understand and maintain, and to guide future refactoring when the underlying
limitations are resolved.

## Background

Based on local testing with recent Octave and statistics package versions:

- `ismissing` behaves equivalently to `isnan` for numeric arrays. Since `pca`
  operates only on numeric matrices, switching from `isnan` to `ismissing`
  does not provide a functional benefit and could affect compatibility with
  older Octave versions.

- `std(x, w)` correctly computes weighted standard deviation for vector inputs.
  However, weighted NaN omission for matrix inputs is not consistently supported
  via `std(X, W, ...)`, which is required by `pca` when performing variable
  scaling in the presence of missing data.

Given these limitations, the existing implementation remains appropriate.

## Changes in this PR

- Clarified `FIXME` comments in `pca.m` to explain:
  - why `isnan` is retained instead of `ismissing`
  - why the `mystd` helper function is still required

- No functional or numerical changes were made.

## Compatibility

- No behavior change  
- No API change  
- Fully backward compatible  

## Future Work (Not Part of This PR)

- Replace `isnan` with `ismissing` once it is guaranteed across supported
  Octave versions and provides a clear advantage for numeric inputs.

- Replace `mystd` with `std(X, W, ..., "omitnan")` once weighted NaN omission
  for matrix inputs is consistently supported and the minimum supported
  Octave version is updated.
