### PR TITLE
Add BISTs to `crosstab`

### DIFF
--- a/inst/crosstab.m
+++ b/inst/crosstab.m
@@ -132,13 +132,13 @@ endfunction
 %!error <crosstab: unsupported type for data vector.> crosstab ([1 2], {1, 2})
 %!test
 %! load carbig
-%! [table, chisq, p, labels] = crosstab (cyl4, when, org);
-%! assert (table(2,3,1), 38);
+%! [t, chisq, p, labels] = crosstab (cyl4, when, org);
+%! assert (t(2,3,1), 38);
 %! assert (labels{3,3}, "Japan");
 %!test
 %! load carbig
-%! [table, chisq, p, labels] = crosstab (cyl4, when, org);
-%! assert (table(2,3,2), 17);
+%! [t, chisq, p, labels] = crosstab (cyl4, when, org);
+%! assert (t(2,3,2), 17);
 %! assert (labels{1,3}, "USA");
 %!test
 %! x = [1, 1, 2, 3, 1];


### PR DESCRIPTION
Hi @pr0m1th3as,

While running `test crosstab`, all the `chi2test` warnings show up, even though the tests pass. Should I supress them inside tests itself? or leave it as is? Thanks.

Example:
```
octave:129> test crosstab
warning: chi2test: Expected values less than 5.
warning: called from
    chi2test at line 339 column 5
    crosstab at line 120 column 8
    __test__ at line 5 column 3
    test at line 685 column 11

warning: chi2test: Expected values less than 5.
warning: called from
    chi2test at line 339 column 5
    crosstab at line 120 column 8
    __test__ at line 6 column 3
    test at line 685 column 11

warning: chi2test: Expected values less than 5.
warning: called from
    chi2test at line 339 column 5
    crosstab at line 120 column 8
    __test__ at line 5 column 3
    test at line 685 column 11

warning: chi2test: Expected values less than 5.
warning: called from
    chi2test at line 339 column 5
    crosstab at line 120 column 8
    __test__ at line 6 column 3
    test at line 685 column 11

warning: chi2test: Expected values less than 1.
warning: called from
    chi2test at line 342 column 5
    crosstab at line 120 column 8
    __test__ at line 6 column 3
    test at line 685 column 11

warning: chi2test: Expected values less than 5.
warning: called from
    chi2test at line 339 column 5
    crosstab at line 120 column 8
    __test__ at line 5 column 3
    test at line 685 column 11

... Few similar warnings below (truncated)

PASSES 29 out of 29 tests
```