### PR TITLE
Fix rangesearch kdtree guards

### DIFF
--- a/inst/rangesearch.m
+++ b/inst/rangesearch.m
@@ -549,5 +549,10 @@ endfunction
 %! X = ones (10,2);
 %! [idx, D] = rangesearch (X, X, 0.1, "NSMethod", "kdtree");
 %! assert (numel (idx), 10);
+%!test
+%! X = ones (3,2);
+%! [idx, D] = rangesearch (X, X, 0.1, "NSMethod", "kdtree", "BucketSize", 1);
+%! assert (numel (idx), 3);
+%! assert (all (cellfun (@numel, idx) == 3));
 %!error<rangesearch: 'kdtree' cannot be used with custom distance functions.> ...
 %! rangesearch (ones (4,2), ones (1,2), 1, "Distance", @(x,y) sqrt(sum((x-y).^2)), "NSMethod", "kdtree")


### PR DESCRIPTION
closes #376 

When all values along a split dimension are equal, the current code can produce `left = all`, `right = empty`, and recurse forever with the same indices. This patch detects such degenerate splits and converts the node to a leaf.

Also disallow kdtree + custom distance, to maintain MATLAB compatability

MATLAB Outputs for referece:
<img width="1194" height="538" alt="image" src="https://github.com/user-attachments/assets/1be54cb9-ec5d-406b-92b3-8c8edd87d228" />

and 

<img width="1042" height="470" alt="image" src="https://github.com/user-attachments/assets/eb88328a-882d-4a4c-b41b-fc8684ae465b" />

All TCs passing
