### PR TITLE
anova1.m: Fix boxplot drawing when figure windows exist

### DIFF
--- a/inst/anova1.m
+++ b/inst/anova1.m
@@ -274,8 +274,19 @@ function [p, anovatab, stats] = anova1 (x, group, displayopt, vartype)
   endif
   ## Plot data using BOXPLOT (unless opted out)
   if (plotdata)
+    ## Create a new figure and ensure it becomes active
+    f = figure ();
+    set (0, "currentfigure", f);
+
+    ## Create a new axes inside this figure and make it current
+    ax = axes ("parent", f);
+    set (f, "currentaxes", ax);
+
+    ## Now boxplot will ALWAYS draw here
     boxplot (x, group_id, "Notch", "on", "Labels", group_names);
+
   endif
+
 endfunction
 
 


### PR DESCRIPTION
While testing `anova1`, I found that the boxplot does not appear if another figure window is already open. This occurs on the Qt graphics toolkit (WSL2, Linux, Windows).

---

### How to reproduce

```matlab
plot(1:10);          % keep this window open
anova1(rand(10,3));  % boxplot does not appear in a new window
```

---

### Observed behavior

- `plot(1:10)` creates a figure normally.
- If that figure remains open, the `anova1` figure does **not** appear in new window, not matching with `matlab` behaviour.

---

### Expected behavior

`anova1` should always open a new figure window and draw its boxplot there, regardless of how many other figure windows are already open, matching MATLAB’s behavior.

---

### Fix

Explicitly select the new figure and create a new axes object as the active context before calling `boxplot`:

```matlab
f  = figure ();
set (0, "currentfigure", f);
ax = axes ("parent", f);
set (f, "currentaxes", ax);
boxplot (x, group_id, "Notch", "on", "Labels", group_names);
```

This ensures that `anova1` always draws its plot in a new and correct figure, regardless of how many figure windows are open.


---

### Notes

- Savannah is currently down. A corresponding bug report will be opened and linked here once it becomes available.