### PR TITLE
Fix `anova1` handling of missing group labels.

### DIFF
--- a/inst/anova1.m
+++ b/inst/anova1.m
@@ -146,15 +146,15 @@ function [p, anovatab, stats] = anova1 (x, group, displayopt, vartype)
     error ("anova1: GROUP must be a vector with the same number of rows as x.");
   endif
 
-  ## Identify NaN values (if any) and remove them from X along with
-  ## their corresponding values from group vector
-  nonan = ! isnan (x);
-  x = x(nonan);
-  group = group(nonan, :);
-
-  ## Convert group to indices and separate names
+  ## Convert group to indices and separate names first
   [group_id, group_names] = grp2idx (group);
   group_id = group_id(:);
+  x = x(:); 
+
+  ## identify NaN values in x or missing/empty categories in the group and remove them.
+  valid_data = !isnan (x) & !isnan (group_id);
+  x = x(valid_data);
+  group_id = group_id(valid_data);
   named = 1;
 
   ## Center data to improve accuracy and keep uncentered data for plotting
@@ -360,3 +360,15 @@ endfunction
 %! assert (tbl{2,5}, 15.523192, 1e-6);
 %! assert (tbl{2,3}, 2, 0);
 %! assert (tbl{2,4}, 7.5786897, 1e-6);
+
+## testing handling of missing values in both data and grouping variables
+%!test
+%! y = [10; 20; 9999; NaN; 40; 50];
+%! g = [1; 1; NaN; 1; 2; 2];
+%! [p, tbl, stats] = anova1 (y, g, "off");
+%! assert (p, 0.051317, 1e-6);
+%! assert (tbl{2,5}, 18, 1e-6);      
+%! assert (tbl{2,3}, 1, 0);          
+%! assert (tbl{3,3}, 2, 0);         
+%! assert (tbl{4,3}, 3, 0);         
+%! assert (stats.n, [2, 2], 0);      


### PR DESCRIPTION
If we have a missing value/NaN as a group label

for eg  : (IN MATLAB)
```
>> y = [10; 20; 3000; 40; 50];
>> group = [1; 1; NaN; 2; 2];
>> [p, tbl, stats] = anova1(y, group, 'off')

p =

    0.0513


tbl =

  4×6 cell array

    {'Source'}    {'SS'  }    {'df'}    {'MS'      }    {'F'       }    {'Prob>F'  }
    {'Groups'}    {[ 900]}    {[ 1]}    {[     900]}    {[      18]}    {[  0.0513]}
    {'Error' }    {[ 100]}    {[ 2]}    {[      50]}    {0×0 double}    {0×0 double}
    {'Total' }    {[1000]}    {[ 3]}    {0×0 double}    {0×0 double}    {0×0 double}


stats = 

  struct with fields:

    gnames: {2×1 cell}
         n: [2 2]
    source: 'anova1'
     means: [15 45]
        df: 2
         s: 7.0711
```
meanwhile in octave : 
```
octave:4> y = [10; 20; 3000; 40; 50];
octave:5> group = [1; 1; NaN; 2; 2];
octave:6> [p, tbl, stats] = anova1(y, group, 'off')
p = 0.4501
tbl =
  4x6 cell array

    {'Source'}    {'SS'         }    {'df'}    {'MS'         }    {'F'       }    {'Prob>F'  }    
    {'Groups'}    {[1.41224e+06]}    {[ 1]}    {[1.41224e+06]}    {[0.750465]}    {[0.450059]}    
    {'Error' }    {[5.64548e+06]}    {[ 3]}    {[1.88183e+06]}    {0x0 char  }    {0x0 char  }    
    {'Total' }    {[7.05772e+06]}    {[ 4]}    {0x0 char     }    {0x0 char  }    {0x0 char  }    

stats =

  scalar structure containing the fields:

    gnames =
    {
      [1,1] = 1
      [2,1] = 2
    }

    n =

       2   2

    source = anova1
    vartype = equal
    means =

       15   45

    vars =

       50   50

    df = 3
    s = 1371.8
```

Fixed it so that the data and the labels are passed to the grp2idx first and then the missing values/NaN values are removed .
