### PR TITLE
check for 2D matrix in `grp2idx`

### DIFF
--- a/inst/grp2idx.m
+++ b/inst/grp2idx.m
@@ -102,7 +102,19 @@ function [g, gn, gl] = grp2idx (s)
     endif
     is_string = true;
     s = cellstr (s);
-  elseif (! (isnumeric (s) || islogical (s) || iscellstr (s)))
+  elseif (isnumeric (s))
+    if (! isvector (s))
+      error ("grp2idx: 'numeric' grouping variable must be a vector.");
+    endif
+  elseif (islogical (s))
+    if (! isvector (s))
+      error ("grp2idx: 'logical' grouping variable must be a vector.");
+    endif
+  elseif (iscellstr (s))
+    if (! isvector (s))
+      error ("grp2idx: 'cell array' grouping variable must be a vector.");
+    endif
+  else
     error ("grp2idx: unsupported type for input S.");
   endif
 
@@ -419,3 +431,6 @@ endfunction
 %!error <grp2idx: 'string' grouping variable must be a vector.> ...
 %! grp2idx (string ({'a', 'a'; 'b', 'c'}))
 %!error <grp2idx: unsupported type for input S.> grp2idx ({1})
+%!error <grp2idx: 'numeric' grouping variable must be a vector.> grp2idx ([10, 20; 10, 30])
+%!error <grp2idx: 'logical' grouping variable must be a vector.> grp2idx ([true, false; false, true])
+%!error <grp2idx: 'cell array' grouping variable must be a vector.> grp2idx ({'a', 'b'; 'c', 'd'})


### PR DESCRIPTION
Currently, these blocks 
```
if (! isvector (s))
      error ("grp2idx: 'categorical' grouping variable must be a vector.");
    endif
```
they only exist for categorical, duration and string type : 

meanwhile passing a numeric, logical, cell string `2D matrix` is processed as single vertical column at the end..
```
octave:3> grp2idx ([10, 20; 10, 30])
ans =

   1
   1
   2
   3

octave:4> grp2idx ([true, false; false, true])
ans =

   2
   1
   1
   2

octave:5> grp2idx ({'a', 'b'; 'c', 'd'})
ans =

   1
   2
   3
   4
```

the same is avoided in matlab : 
```
>> grp2idx ([10, 20; 10, 30])
Error using statslib.internal.grp2idx (line 42)
Grouping variable must be a vector, character array, string array, or cell array of character vectors.

Error in grp2idx (line 28)
[varargout{1:nargout}] = statslib.internal.grp2idx(s);
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

>> grp2idx ([true, false; false, true])
Error using statslib.internal.grp2idx (line 42)
Grouping variable must be a vector, character array, string array, or cell array of character vectors.

Error in grp2idx (line 28)
[varargout{1:nargout}] = [statslib.internal.grp2idx](matlab:matlab.lang.internal.introspective.errorDocCallback('statslib.internal.grp2idx', '/MATLAB/toolbox/shared/statslib/+statslib/+internal/grp2idx.m', 42))(s);
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

>> grp2idx ({'a', 'b'; 'c', 'd'})
Error using statslib.internal.grp2idx ([line 42](matlab: opentoline('/MATLAB/toolbox/shared/statslib/+statslib/+internal/grp2idx.m',42,0)))
Grouping variable must be a vector, character array, string array, or cell array of character vectors.

Error in [grp2idx](matlab:matlab.lang.internal.introspective.errorDocCallback('grp2idx', '/MATLAB/toolbox/stats/stats/grp2idx.m', 28)) ([line 28](matlab: opentoline('/MATLAB/toolbox/stats/stats/grp2idx.m',28,0)))
[varargout{1:nargout}] = statslib.internal.grp2idx(s);
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```
