### PR TITLE
improve `makima interpolation`.

### DIFF
--- a/inst/makima.m
+++ b/inst/makima.m
@@ -1,4 +1,5 @@
-## Copyright (C) 2025 Avanish Salunke <avanishsalunke16@gmail.com>
+## Copyright (C) 2026 Andreas Bertsatos <abertsatos@biol.uoa.gr>
+## Copyright (C) 2026 Avanish Salunke <avanishsalunke16@gmail.com>
 ##
 ## This file is part of the statistics package for GNU Octave.
 ##
@@ -21,84 +22,142 @@
 ## @deftypefnx {statistics} {@var{yi} =} makima (@var{y}, @var{xq})
 ## @deftypefnx {statistics} {@var{yi} =} makima (@dots{}, @qcode{"extrap"})
 ##
-## Compute the 1-D Modified Akima (MAKIMA) interpolant of sample data
-## @var{x}, @var{y} evaluated at query points @var{xq}.
+## Compute the 1-D Modified Akima piecewise cubic Hermite interpolant of
+## sample data @var{x} and @var{y}.
 ##
-## The MAKIMA method generates a **shape-preserving piecewise cubic Hermite**
-## interpolant using a modified Akima derivative estimation method.
+## The Modified Akima (MAKIMA) algorithm generates a shape-preserving 
+## piecewise cubic interpolant. It differs from standard splines by avoiding
+## excessive local undulations and overshoots, and it connects collinear points
+## (flat regions) with straight lines. It is particularly well-suited for
+## oscillatory data where @code{pchip} might aggressively flatten local
+## extrema.
 ##
-## For a strictly increasing vector of sample points @var{x} and corresponding
-## values @var{y}, the function returns the interpolated values @var{yi} at the
-## query points @var{xq}.
+## The sample points @var{x} must be a vector of unique values. If @var{x}
+## is not sorted, the function will automatically sort it and rearrange
+## @var{y} accordingly.
 ##
-## If only two inputs are given, @var{x} is assumed to be
-## @code{[1:length(@var{y})]}.
+## The sample values @var{y} can be a scalar, vector, or an N-dimensional
+## array. If @var{y} is an N-dimensional array, the interpolation is
+## performed along its last dimension, which must have the same length as
+## @var{x}. Complex values for @var{y} are supported.
 ##
-## The optional string @qcode{"extrap"} enables extrapolation for query points
-## outside the range of @var{x}. By default, extrapolation returns @qcode{NaN}.
+## If query points @var{xq} are provided, the function evaluates the 
+## interpolant and returns the interpolated values @var{yi}. By default,
+## @code{makima} uses the boundary polynomials to extrapolate for points 
+## outside the range of @var{x}. The optional string argument @qcode{"extrap"} 
+## is accepted for compatibility with other interpolation functions.
+##
+## If only @var{x} and @var{y} are provided, the function returns a 
+## piecewise polynomial structure @var{pp} that represents the interpolant.
+## This structure can be evaluated later at specific query points using
+## @code{ppval}.
+##
+## Evaluating the interpolant at query points outside the domain of @var{x}
+## automatically extrapolates using the boundary polynomials.
 ##
 ## @seealso{interp1, pchip, spline}
 ## @end deftypefn
 
-
 function yi = makima (x, y, xq, varargin)
-
-  if (nargin == 2)
-    xq = y;
-    y = x;
-    x = (1:numel (y)).';
-  elseif (nargin != 3 && nargin != 4)
+  if (nargin < 2 || nargin > 4)
     error ("makima: invalid number of inputs");
   endif
 
-  is_row_input = isrow (xq);
+  if (nargin == 4 && ! strcmpi (varargin{1}, "extrap"))
+    error ("makima: unknown option '%s'", varargin{1});
+  endif
 
-  extrapolate = false;
-  if (nargin == 4)
-    if (ischar (varargin{1}) && strcmpi (varargin{1}, "extrap"))
-      extrapolate = true;
-    else
-      error ("makima: unknown option '%s'", varargin{1});
-    endif
+  return_pp = (nargin == 2);
+
+  if (! return_pp)
+    size_xq = size (xq);
   endif
 
   x = x(:);
   n = numel (x);
 
-  if (isvector (y))
+  is_y_vector = isvector (y);
+  size_y = size (y);
+
+  if (is_y_vector)
+    if (numel (y) != n)
+      error ("makima: The number of sample points X, %d, is incompatible with the number of values Y, %d.", n, numel (y));
+    endif
     y = y(:);
-  endif
-  [ry, nc] = size (y);
-  if (ry != n)
-    error ("makima: x and y must have the same number of rows");
+    dim_y = 1;
+    nc = 1;
+  else
+    dim_y = ndims (y);
+    if (size_y(dim_y) != n)
+      error ("makima: The number of sample points X, %d, is incompatible with the number of values Y, %d.", n, size_y(dim_y));
+    endif
+
+    ## permute the interpolation dimension to be the first
+    perm_order = 1:numel (size_y);
+    perm_order(dim_y) = 1;
+    perm_order(1) = dim_y;
+
+    y = permute (y, perm_order);
+    nc = numel (y) / n;
+    y = reshape (y, n, nc);
   endif
 
   if (iscomplex (y))
-    yi = makima (x, real (y), xq, varargin{:}) + 1i * makima (x, imag (y), xq, varargin{:});
-    if (is_row_input && nc == 1)
-      yi = yi.';
+    if (return_pp)
+      ## Build complex pp struct
+      pp_real = makima (x, real (y));
+      pp_imag = makima (x, imag (y));
+      yi = pp_real;
+      yi.coefs = pp_real.coefs + 1i * pp_imag.coefs;
+    else
+      yi = makima (x, real (y), xq, varargin{:}) + 1i * makima (x, imag (y), xq, varargin{:});
     endif
     return;
   endif
 
-  if (n == 1)
-    yi = repmat (y(1, :), numel (xq(:)), 1);
-    if (is_row_input && nc == 1)
-      yi = yi.';
-    endif
-    return;
-  elseif (n == 2)
-    yi = interp1 (x, y, xq, "linear", extrapolate);
-    if (is_row_input && nc == 1 && iscolumn (yi))
-       yi = yi.';
-    endif
-    return;
+  if (! return_pp)
+    xqv = xq(:);
+    nq = numel (xqv);
   endif
 
-  dx = diff (x);
-  if (any (dx <= 0))
-    error ("makima: x must be strictly increasing");
+  if (n < 2)
+    error ("makima: The first two inputs must have at least two elements.");
   endif
+
+  if (! issorted (x))
+    [x, sort_idx] = sort (x);
+    y = y(sort_idx, :);
+  endif
+
+  math_done = false;
+  if (n == 2)
+    if (return_pp)
+      ## Linear coefficients for 2-point pp struct
+      coefs = zeros (nc, 4, class (y));
+      coefs(:, 3) = (y(2, :).' - y(1, :).') ./ (x(2) - x(1));
+      coefs(:, 4) = y(1, :).';
+      
+      if (is_y_vector)
+        dim_out = 1;
+      else
+        dim_out = size_y;
+        dim_out(dim_y) = [];
+      endif
+      yi = mkpp (x.', coefs, dim_out);
+      return;
+    else
+      yi = interp1 (x, y, xqv, "linear", "extrap");
+      yi = reshape (yi, [nq, nc]); 
+      math_done = true;
+    endif
+  endif
+
+  if (! math_done)
+    dx = diff (x);
+  
+    if (any (dx <= 0))
+      error ("makima: The sample points x must be unique.");
+    endif
   dy = diff (y);
   m = dy ./ dx;
 
@@ -132,14 +191,44 @@ function yi = makima (x, y, xq, varargin)
     d(zero_mask) = fallback(zero_mask);
   endif
 
-  xqv = xq(:);
-  nq = numel (xqv);
+  if (return_pp)
+    hseg = dx;
+    delta = m;
+    
+    d0 = d(1:end-1, :);
+    d1 = d(2:end, :);
+    y0 = y(1:end-1, :);
+    
+    c3 = (d0 + d1 - 2*delta) ./ (hseg .* hseg);
+    c2 = (3*delta - 2*d0 - d1) ./ hseg;
+    c1 = d0;
+    c0 = y0;
+    
+    c3_t = c3.';
+    c2_t = c2.';
+    c1_t = c1.';
+    c0_t = c0.';
+    
+    coefs = [c3_t(:), c2_t(:), c1_t(:), c0_t(:)];
+    
+    if (is_y_vector)
+      dim_out = 1;
+    else
+      dim_out = size_y;
+      dim_out(dim_y) = [];
+      if (isempty (dim_out))
+        dim_out = 1;
+      endif
+    endif
+
+    yi = mkpp (x.', coefs, dim_out);
+    return;
+  endif
+
   yi = NaN (nq, nc, class (y));
 
   if (nq > 0)
     idx = lookup (x, xqv);
-    left_mask  = (xqv < x(1));
-    right_mask = (xqv > x(end));
 
     idx (idx >= n) = n - 1;
     idx (idx == 0) = 1;
@@ -162,173 +251,235 @@ function yi = makima (x, y, xq, varargin)
       yi(:, c) = y0 + s .* (d0 + s .* (c2 + s .* c3));
     endfor
 
-    if (! extrapolate)
-      yi(left_mask, :)  = NaN;
-      yi(right_mask, :) = NaN;
-    endif
   endif
 
-  if (is_row_input && nc == 1)
-    yi = yi.';
+  endif
+
+  if (! return_pp)
+    if (is_y_vector)
+      yi = reshape (yi, size_xq);
+    else
+      out_shape = size_y;
+      out_shape(dim_y) = nq;
+      
+      yi = reshape (yi, out_shape(perm_order));
+      yi = ipermute (yi, perm_order);
+      
+      ## only append size_xq if multi-dimensional array is given
+      if (! isvector (xq))
+        final_shape = size_y;
+        final_shape(dim_y) = [];
+        final_shape = [final_shape, size_xq];
+        
+        yi = reshape (yi, final_shape);
+      endif
+    endif
   endif
 
 endfunction
 
 
 %!test
-%! % 1. Basic linear-like data
+%! ## Basic linear-like data
 %! x = [1; 2; 3; 4];
 %! y = [2; 4; 6; 8];
 %! xi = [1.5; 2.5; 3.5];
 %! yi = makima (x, y, xi);
 %! assert (yi, [3; 5; 7], 1e-12);
-
 %!test
-%! % 2. Nonlinear dataset (finite check)
+%! ## Nonlinear dataset (finite check)
 %! x = [0; 1; 2; 3; 4];
 %! y = [0; 1; 0; 1; 0];
 %! xi = linspace (0,4,20)';
 %! yi = makima (x, y, xi);
 %! assert (all (isfinite (yi)));
-
 %!test
-%! % 3. makima(y, xq) syntax
-%! y = [10; 20; 30];
-%! xq = [1; 2; 3];
-%! yi = makima (y, xq);
-%! assert (yi, y, 1e-12);
-
+%! ## pp structure output
+%! x = [1; 2; 3; 4];
+%! y = [2; 4; 6; 8];
+%! pp = makima (x, y);
+%! assert (isstruct (pp));
+%! assert (strcmp (pp.form, "pp"));
+%! assert (pp.pieces, 3);
+%! assert (pp.order, 4);
 %!test
-%! % 4. Matrix y input (multiple columns)
+%! ## Matrix y input.
 %! x = [1; 3; 5];
-%! y = [1 2; 3 4; 2 6];
+%! y = [1 3 2; 2 4 6]; 
 %! xi = 2;
 %! yi = makima (x, y, xi);
-%! assert (columns(yi), 2);
+%! assert (size(yi), [2, 1]);
 %! assert (all (isfinite (yi)));
-%! % Column 1 exact value (1917/832)
-%! assert (yi(1), 2.3040865384615385, 1e-12);
-%! % Column 2 exact value (Linear)
-%! assert (yi(2), 3.000, 1e-12);
-
+%! assert (yi(1), 2.304086538461538, 1e-12);
+%! assert (yi(2), 3.000000000000000, 1e-12);
 %!test
-%! % 5. Extrapolation enabled
-%! x = [1; 2; 3];
-%! y = [5; 10; 15];
-%! xi = [0; 4];
-%! yi = makima (x, y, xi, "extrap");
-%! assert (all (isfinite (yi)));
-%! assert (yi, [0; 20], 1e-12);
-
-%!test
-%! % 6. Default NaN extrapolation
+%! ## Extrapolation through default method.
 %! x = [1; 2; 3];
 %! y = [5; 10; 15];
 %! xi = [0; 4];
 %! yi = makima (x, y, xi);
-%! assert (isnan (yi(1)));
-%! assert (isnan (yi(2)));
-
+%! assert (all (isfinite (yi)));
+%! assert (yi, [0; 20], 1e-12);
 %!test
-%! % 7. Complex interpolation
+%! ## Complex interpolation.
 %! x = [1; 2; 4];
 %! y = [1+2i; 2+3i; 4+8i];
 %! xi = 3;
 %! yi = makima (x, y, xi);
 %! assert (yi, 3 + 5.09767206477733i, 1e-12);
 %! assert (iscomplex (yi));
-
 %!test
-%! % 8. Single Point Input (1x1)
-%! x = 5;
-%! y = 12;
-%! xi = 5;
-%! yi = makima (x, y, xi);
-%! assert (yi, 12, 1e-12);
-
-%!test
-%! % 9. Two-point interpolation (Linear fallback)
+%! ## Two-point interpolation.
 %! x = [1; 5];
 %! y = [10; 30];
 %! xi = 3;
 %! yi = makima (x, y, xi);
 %! assert (yi, 20, 1e-12);
-
 %!test
-%! % 10. Single Precision Input
+%! ## Single Precision Input.
 %! x = single ([1; 2; 3]);
 %! y = single ([10; 20; 30]);
 %! xi = single (1.5);
 %! yi = makima (x, y, xi);
 %! assert (isa (yi, "single"));
 %! assert (yi, single (15), 1e-6);
-
 %!test
-%! % 11. Row vector inputs (Orientation check)
+%! ## Row vector inputs.
 %! x = [1 2 3];
 %! y = [4 5 6];
 %! xi = [1.5 2.5];
 %! yi = makima (x, y, xi);
 %! assert (yi, [4.5 5.5], 1e-12);
-
 %!test
-%! % 12. Step function (Overshoot Check)
+%! ## Step function.
 %! x = [1 2 3 4 5 6];
 %! y = [0 0 1 1 0 0];
 %! xi = [2.5 3.5 4.5];
 %! yi = makima (x, y, xi);
-%! expected_12 = [0.5000, 1.1250, 0.5000];
-%! assert (yi, expected_12, 1e-12);
-
+%! expected_11 = [0.5000, 1.1250, 0.5000];
+%! assert (yi, expected_11, 1e-12);
 %!test
-%! % 13. Runge function (Oscillation Check)
+%! ## Runge function (Oscillation Check)
 %! x = linspace (-1, 1, 7)';
 %! y = 1 ./ (1 + 25 * x.^2);
 %! xi = [-0.5; 0.1; 0.5];
 %! yi = makima (x, y, xi);
-%! expected_13 = [0.148690385982729; 0.857734549516009; 0.148690385982729];
-%! assert (yi, expected_13, 1e-12);
-
+%! expected_12 = [0.148690385982729; 0.857734549516009; 0.148690385982729];
+%! assert (yi, expected_12, 1e-12);
 %!test
-%! % 14. Constant Slopes / Zero Weights
+%! ## Constant Slopes / Zero Weights
 %! x = [1; 2; 3; 4; 5];
 %! y = [1; 1; 1; 1; 1];
 %! xi = 3.5;
 %! yi = makima (x, y, xi);
-%! expected_14 = [1];
-%! assert (yi, expected_14, 1e-12);
-
+%! expected_13 = [1];
+%! assert (yi, expected_13, 1e-12);
 %!test
-%! % 15. Empty xq input
+%! ## Empty xq input
 %! x = [1; 2; 3];
 %! y = [4; 5; 6];
 %! xi = [];
 %! yi = makima (x, y, xi);
 %! assert (isempty (yi));
-%! assert (iscolumn (yi)); % Ensure it defaults to column output
-
+%! assert (! (iscolumn (yi)));
 %!test
-%! % 16. Wide range of y-values
+%! ## Wide range of y-values
 %! x = [1e-10; 2e-10; 3e-10; 4e-10];
 %! y = [1e10; 2e10; 3e10; 4e10];
 %! xi = 2.5e-10;
 %! yi = makima (x, y, xi);
-%! assert (yi, 2.5e10, 1e-6); % Using a slightly relaxed tolerance
-
+%! assert (yi, 2.5e10, 1e-12); 
 %!test
-%! % 17. Single column matrix input (ensures nc=1 logic works)
+%! ## Single column matrix input.
 %! x = [1; 2; 3];
 %! y = [10; 20; 30];
 %! xi = [1.5 2.5]; % Row input
 %! yi = makima (x, y, xi);
 %! assert (yi, [15 25], 1e-12);
 %! assert (isrow (yi));
-
-%!error<makima: x must be strictly increasing>
-%! makima ([1 1 2], [3 4 5], 1.5)
-
-%!error<makima: x and y must have the same number of rows>
-%! makima ([1;2;3], [1;2], 2)
-
-%!error<makima: invalid number of inputs>
-%! makima (1)
+%!test
+%! ## Evaluate pp structure with ppval
+%! x = [1; 2; 3; 4];
+%! y = [2; 4; 6; 8];
+%! xi = [1.5; 2.5; 3.5];
+%! pp = makima (x, y);
+%! yi_ppval = ppval (pp, xi);
+%! yi_direct = makima (x, y, xi);
+%! assert (yi_ppval, yi_direct, 1e-12);
+%!test
+%! ## xq is a 2x2 matrix
+%! x = [1; 2; 3; 4; 5];
+%! y = [10; 20; 15; 5; 25];
+%! xq = [1.5, 2.5; 3.5, 4.5];
+%! yi = makima (x, y, xq);
+%! assert (size (yi), [2, 2]);
+%! expected = [16.85897435897436, 18.22916666666667; 9.81182795698925, 10.84522332506203];
+%! assert (yi, expected, 1e-12);
+%!test
+%! ## xq is a 3D array
+%! x = [1; 2; 3; 4; 5];
+%! y = [10; 20; 15; 5; 25];
+%! xq = ones (2, 2, 2) * 2.5;
+%! yi = makima (x, y, xq);
+%! assert (size (yi), [2, 2, 2]);
+%!test
+%! ## pp structure with matrix y input
+%! x = [1; 3; 5];
+%! y = [1 3 2; 2 4 6]; 
+%! pp = makima (x, y);
+%! assert (isstruct (pp));
+%! assert (pp.pieces, 2);
+%! assert (pp.dim, 2);
+%! yi_ppval = ppval (pp, 2);
+%! yi_direct = makima (x, y, 2);
+%! assert (yi_ppval, yi_direct, 1e-12);
+%!test
+%! ## y is a 3D array [2x3x4] and x is length 4
+%! x = [1, 2, 3, 4];
+%! xq = [1.5, 2.5, 3.5];
+%! y3 = reshape (1:24, [2, 3, 4]);
+%! yi = makima (x, y3, xq);
+%! assert (size (yi), [2, 3, 3]);
+%!test
+%! ## Unsorted 'x' inputs 
+%! x_unsorted = [3; 1; 2; 4];
+%! y_unsorted = [9; 1; 4; 16];
+%! xq = [1.5; 2.5];
+%! x_sorted = [1; 2; 3; 4];
+%! y_sorted = [1; 4; 9; 16];
+%! assert (makima (x_unsorted, y_unsorted, xq), makima (x_sorted, y_sorted, xq), 1e-12);
+%!test
+%! ## Complex piecewise polynomial (pp) structure
+%! x = [1 2 3];
+%! y = [1 4 9] + 1i * [2 8 18];
+%! pp = makima (x, y);
+%! assert (isstruct (pp));
+%! assert (iscomplex (pp.coefs));
+%! assert (ppval (pp, 1.5), makima (x, y, 1.5), 1e-12);
+%!test
+%! ## N-dimensional y (3D) with N-dimensional xq (2x2 matrix)
+%! x = [1 2 3 4];
+%! y3 = reshape (1:24, [2 3 4]);
+%! xq = [1.5 2.5; 3.5 1.5];
+%! yi = makima (x, y3, xq);
+%! assert (size (yi), [2 3 2 2]);
+%!test
+%! ## 2-point pp struct 
+%! x = [1; 5];
+%! y = [10; 30];
+%! pp = makima (x, y);
+%! assert (pp.pieces, 1);
+%! assert (pp.order, 4);
+%! assert (ppval (pp, 3), 20, 1e-12);
+%!test
+%! ## Exact Collinearity
+%! x = [1 2 3 4];
+%! y = [2 4 6 8];
+%! xi = 2.5;
+%! yi = makima (x, y, xi);
+%! assert (yi, 5, 1e-12);
+%!error <makima: The sample points x must be unique.> makima ([1 1 2], [3 4 5], 1.5)
+%!error <makima: invalid number of inputs> makima (1)
+%!error <makima: The first two inputs must have at least two elements.> makima (1, 2, 1.5)
+%!error <makima: The number of sample points X, 4, is incompatible with the number of values Y, 5.> makima ([1 2 3 4], [1 2 3 4 5], 2)
+%!error <makima: unknown option 'linear'> makima ([1 2 3], [1 2 3], 2, "linear")

--- a/inst/makima.m
+++ b/inst/makima.m
@@ -1,5 +1,4 @@
-## Copyright (C) 2026 Andreas Bertsatos <abertsatos@biol.uoa.gr>
-## Copyright (C) 2026 Avanish Salunke <avanishsalunke16@gmail.com>
+## Copyright (C) 2025-2026 Avanish Salunke <avanishsalunke16@gmail.com>
 ##
 ## This file is part of the statistics package for GNU Octave.
 ##
@@ -81,7 +80,7 @@ function yi = makima (x, y, xq, varargin)
 
   if (is_y_vector)
     if (numel (y) != n)
-      error ("makima: The number of sample points X, %d, is incompatible with the number of values Y, %d.", n, numel (y));
+      error ("makima: the number of sample points X, %d, is incompatible with the number of values Y, %d.", n, numel (y));
     endif
     y = y(:);
     dim_y = 1;
@@ -89,7 +88,7 @@ function yi = makima (x, y, xq, varargin)
   else
     dim_y = ndims (y);
     if (size_y(dim_y) != n)
-      error ("makima: The number of sample points X, %d, is incompatible with the number of values Y, %d.", n, size_y(dim_y));
+      error ("makima: the number of sample points X, %d, is incompatible with the number of values Y, %d.", n, size_y(dim_y));
     endif
 
     ## permute the interpolation dimension to be the first
@@ -121,7 +120,7 @@ function yi = makima (x, y, xq, varargin)
   endif
 
   if (n < 2)
-    error ("makima: The first two inputs must have at least two elements.");
+    error ("makima: the first two inputs must have at least two elements.");
   endif
 
   if (! issorted (x))
@@ -156,7 +155,7 @@ function yi = makima (x, y, xq, varargin)
     dx = diff (x);
   
     if (any (dx <= 0))
-      error ("makima: The sample points x must be unique.");
+      error ("makima: the sample points x must be unique.");
     endif
   dy = diff (y);
   m = dy ./ dx;
@@ -486,9 +485,9 @@ endfunction
 %! yi = makima (x, y, xi, "extrap");
 %! assert (all (isfinite (yi)));
 %! assert (yi, [0; 20], 1e-12);
-%!error <makima: The sample points x must be unique.> makima ([1 1 2], [3 4 5], 1.5)
+%!error <makima: the sample points x must be unique.> makima ([1 1 2], [3 4 5], 1.5)
 %!error <makima: invalid number of inputs> makima (1)
-%!error <makima: The first two inputs must have at least two elements.> makima (1, 2, 1.5)
-%!error <makima: The number of sample points X, 4, is incompatible with the number of values Y, 5.> makima ([1 2 3 4], [1 2 3 4 5], 2)
+%!error <makima: the first two inputs must have at least two elements.> makima (1, 2, 1.5)
+%!error <makima: the number of sample points X, 4, is incompatible with the number of values Y, 5.> makima ([1 2 3 4], [1 2 3 4 5], 2)
 %!error <makima: unknown option 'linear'> makima ([1 2 3], [1 2 3], 2, "linear")
 %!error <makima: invalid number of inputs> makima ([1 2 3], [1 2 3], 2, "extrap", "too_many")

--- a/inst/makima.m
+++ b/inst/makima.m
@@ -478,8 +478,17 @@ endfunction
 %! xi = 2.5;
 %! yi = makima (x, y, xi);
 %! assert (yi, 5, 1e-12);
+%!test
+%! ## Extrapolation check.
+%! x = [1; 2; 3];
+%! y = [5; 10; 15];
+%! xi = [0; 4];
+%! yi = makima (x, y, xi, "extrap");
+%! assert (all (isfinite (yi)));
+%! assert (yi, [0; 20], 1e-12);
 %!error <makima: The sample points x must be unique.> makima ([1 1 2], [3 4 5], 1.5)
 %!error <makima: invalid number of inputs> makima (1)
 %!error <makima: The first two inputs must have at least two elements.> makima (1, 2, 1.5)
 %!error <makima: The number of sample points X, 4, is incompatible with the number of values Y, 5.> makima ([1 2 3 4], [1 2 3 4 5], 2)
 %!error <makima: unknown option 'linear'> makima ([1 2 3], [1 2 3], 2, "linear")
+%!error <makima: invalid number of inputs> makima ([1 2 3], [1 2 3], 2, "extrap", "too_many")


### PR DESCRIPTION
> revisit to some old implementation.

Made it compatible with matlab significantly : 

1. N-dim arrays are now supported.
2. Piecewise Polynomail generation : now it is building and returning standard octave pp structure (using mkpp).
3. handling unsorted data.
4. error handling
5. bists
6. documentation

