### PR TITLE
handle Nan values in `signrank` and fix typos.

### DIFF
--- a/inst/Classification/ClassificationDiscriminant.m
+++ b/inst/Classification/ClassificationDiscriminant.m
@@ -751,7 +751,7 @@ classdef ClassificationDiscriminant
         endfor
         this.Sigma = this.Sigma / (this.NumObservations - num_classes);
 
-        ## Check for predictors wih zero within-class variance
+        ## Check for predictors with zero within-class variance
         zwcv = find (diag (this.Sigma) == 0);
         if (! isempty (zwcv))
           msg = strcat ("ClassificationDiscriminant: Predictor", ...

--- a/inst/dist_fun/wblpdf.m
+++ b/inst/dist_fun/wblpdf.m
@@ -96,7 +96,7 @@ function y = wblpdf (x, varargin)
 endfunction
 
 %!demo
-%! ## Plot various PDFs from the Weibul distribution
+%! ## Plot various PDFs from the Weibull distribution
 %! x = 0:0.001:2.5;
 %! y1 = wblpdf (x, 1, 0.5);
 %! y2 = wblpdf (x, 1, 1);
@@ -107,7 +107,7 @@ endfunction
 %! ylim ([0, 2.5])
 %! legend ({"λ = 5, k = 0.5", "λ = 9, k = 1", ...
 %!          "λ = 6, k = 1.5", "λ = 2, k = 5"}, "location", "northeast")
-%! title ("Weibul PDF")
+%! title ("Weibull PDF")
 %! xlabel ("values in x")
 %! ylabel ("density")
 

--- a/inst/fillmissing.m
+++ b/inst/fillmissing.m
@@ -78,7 +78,7 @@
 ## piecewise cubic spline interpolation of neigboring, non-missing values
 ##
 ## @item pchip
-## 'shape preserving' piecewise cubic spline interposaliton of neighboring,
+## 'shape preserving' piecewise cubic spline interpolation of neighboring,
 ## non-missing values
 ## @end table
 ##

--- a/inst/signrank.m
+++ b/inst/signrank.m
@@ -177,8 +177,7 @@ function [p, h, stats] = signrank (x, my, varargin)
 
   ## Calculate differences between X and Y vectors: remove equal values of NaNs
   XY_diff = x(:) - my(:);
-  NO_diff = (XY_diff == 0);
-  XY_diff(NO_diff | isnan (NO_diff)) = [];
+  XY_diff(XY_diff == 0 | isnan (XY_diff)) = [];
 
   ## Recalculate remaining length of X vector (after equal or NaNs removal)
   n = length (XY_diff);
@@ -317,6 +316,11 @@ endfunction
 %! assert (h, false);
 %! assert (stats.zval, 2.0966, 1e-4);
 %! assert (stats.signedrank, 21);
+%!test
+%! x = [1, 2, 3, NaN, 4, 5];
+%! p_clean = signrank ([1, 2, 3, 4, 5]);
+%! p_nan   = signrank (x);
+%! assert (p_nan, p_clean);
 
 ## Test input validation
 %!error <signrank: X must be a vector.> signrank (ones (2))


### PR DESCRIPTION
1. Handle Nan values the same way as of https://github.com/gnu-octave/statistics/pull/405
2. Fix some typos following https://github.com/gnu-octave/statistics/pull/406