### PR TITLE
Relax tolerance of unit test in canoncorr.m

### DIFF
--- a/inst/canoncorr.m
+++ b/inst/canoncorr.m
@@ -93,7 +93,7 @@ endfunction
 %! [A, B, r, U, V, stats] = canoncorr (X, Y);
 %! Cuv = (U' * V) / (k - 1);
 %!assert (diag (Cuv)', r, 10 * eps);
-%!assert (diag (diag (Cuv)), Cuv, eps);
+%!assert (diag (diag (Cuv)), Cuv, 2 * eps);
 %!assert (r, [0.99590, 0.26754], 1E-5);
 %!assert (U, center(X) * A, 10 * eps);
 %!assert (V, center(Y) * B, 10 * eps);


### PR DESCRIPTION
Needed for amd64 and armhf Debian architectures with Octave 11.

See the following log files:
https://buildd.debian.org/status/fetch.php?pkg=octave-statistics&arch=amd64&ver=1.8.1-3%2Bb1&stamp=1772693511&raw=0
https://buildd.debian.org/status/fetch.php?pkg=octave-statistics&arch=armhf&ver=1.8.1-3%2Bb1&stamp=1772659910&raw=0