### PR TITLE
improve `cmdscale` to support another argument.

### DIFF
--- a/inst/cmdscale.m
+++ b/inst/cmdscale.m
@@ -1,4 +1,5 @@
 ## Copyright (C) 2014 JD Walsh <walsh@math.gatech.edu>
+## Copyright (C) 2026 Avanish Salunke <avanishsalunke16@gmail.com>
 ##
 ## This file is part of the statistics package for GNU Octave.
 ##
@@ -75,41 +76,47 @@
 ## @seealso{pdist}
 ## @end deftypefn
 
-function [Y, e] = cmdscale (D)
+function [Y, e] = cmdscale (D, p)
 
-  % Check for matrix input
-  if ((nargin ~= 1) || ...
-      (~any(strcmp ({'matrix' 'scalar' 'range'}, typeinfo(D)))))
-    usage ('cmdscale: input must be vector or matrix; see help');
+  ## Check for matrix input and valid number of arguments
+  if (nargin < 1 || nargin > 2 || ! isnumeric (D) || ! ismatrix (D))
+    error ("cmdscale: input must be a numeric vector or matrix.");
   endif
 
-  % If vector, convert to matrix; otherwise, check for square symmetric input
+  ## If vector, convert to matrix; otherwise, check for square symmetric input
   if (isvector (D))
     D = squareform (D);
-  elseif ((~issquare (D)) || (norm (D - D', 1) > 0))
-    usage ('cmdscale: matrix input must be square symmetric; see help');
+  elseif (! issquare (D) || norm (D - D', 1) > 0)
+    error ("cmdscale: matrix input must be square symmetric.");
   endif
 
-  n = size (D,1);
-  % Check for valid format (see help above); If similarity matrix, convert
+  n = size (D, 1);
+
+  if (nargin > 1 && ! isempty (p))
+    if (! isscalar (p) || ! isreal (p) || p != round (p) || p < 1 || p > n)
+      error ("cmdscale: p must be an integer between 1 and %d.", n);
+    endif
+  endif
+
+  ## Check for valid format and if similarity matrix, convert
   if (any (any (D < 0)))
-    usage ('cmdscale: entries must be nonnegative; see help');
-  elseif (trace (D) ~= 0)
-      if ((~all (diag (D) == 1)) || (~all (D <= 1)))
-        usage ('cmdscale: input must be distance vector or matrix; see help');
-      endif
-      D = sqrt (ones (n,n) - D);
+    error ("cmdscale: entries must be nonnegative.");
+  elseif (trace (D) != 0)
+    if (!all (diag (D) == 1) || !all (D(:) <= 1))
+      error ("cmdscale: input must be a distance vector or matrix.");
+    endif
+    D = sqrt (ones (n,n) - D);
   endif
 
-  % Build centering matrix, perform double centering, extract eigenpairs
+  ## Build centering matrix, perform double centering, extract eigenpairs
   J = eye (n) - ones (n,n) / n;
   B = -1 / 2 * J * (D .^ 2) * J;
   [Q, e] = eig (B);
   e = diag (e);
   etmp = e;
-  e = sort(e, 'descend');
+  e = sort (e, 'descend');
 
-  % Remove complex eigenpairs (only possible due to machine approximation)
+  ## Remove complex eigenpairs (only possible due to machine approximation)
   if (iscomplex (etmp))
     for i = 1 : size (etmp,1)
       cmp(i) = (isreal (etmp(i)));
@@ -118,28 +125,76 @@ function [Y, e] = cmdscale (D)
     Q = Q(:,cmp);
   endif
 
-  % Order eigenpairs
+  ## Order eigenpairs
   [etmp, ord] = sort (etmp, 'descend');
   Q = Q(:,ord);
 
-  % Remove negative eigenpairs
-  cmp = (etmp > 0);
-  etmp = etmp(cmp);
-  Q = Q(:,cmp);
+  ## determine total strictly positive eigenvalues
+  tol = n * max (abs (etmp)) * eps;
+  n_pos = sum (etmp > tol);
 
-  % Test for n-dimensional results
-  if (size(etmp,1) == n)
-    etmp = etmp(1:n-1);
-    Q = Q(:, 1:n-1);
+  if (nargin > 1 && ! isempty (p))
+    ## if p is given, eigenvalue output length is exactly p
+    e = etmp(1:p);
+    k = min (p, n_pos);
+  else
+    e = etmp;
+    k = n_pos;
+    
+    if (k == n)
+      k = n - 1;
+    endif
   endif
 
-  % Build output matrix Y
+  ## build output matrix Y by safely slicing the top k elements
+  etmp = etmp(1:k);
+  Q = Q(:, 1:k);
   Y = Q * diag (sqrt (etmp));
 
 endfunction
 
+%!test
 %!shared m, n, X, D
-%! m = randi(100) + 1; n = randi(100) + 1; X = rand(m, n); D = pdist(X);
-%!assert(norm(pdist(cmdscale(D))), norm(D), sqrt(eps))
-%!assert(norm(pdist(cmdscale(squareform(D)))), norm(D), sqrt(eps))
+%! m = randi (100) + 1;
+%! n = randi (100) + 1;
+%! X = rand (m, n);
+%! D = pdist (X);
+%!assert (norm (pdist (cmdscale (D))), norm (D), sqrt (eps))
+%!assert (norm (pdist (cmdscale (squareform (D)))), norm (D), sqrt (eps))
+%!test
+%! ## basic dimentionality reduction
+%! D = [0 2 3; 2 0 4; 3 4 0];
+%! [Y, e] = cmdscale (D, 2);
+%! assert (size (Y, 2), 2);
+%! assert (length (e), 2);
+%!test
+%! ## oversized dimension
+%! X = [0 0; 1 0; 0 1; 1 1];
+%! D = pdist (X);
+%! [Y, e] = cmdscale (D, 3);
+%! assert (size (Y, 2), 2);
+%! assert (length (e), 3);
+%!test
+%! ## non euclidean distance.
+%! X = [1 2; 3 4; 5 6; 7 8; 9 10];
+%! D = pdist (X, "cityblock");
+%! [Y, e] = cmdscale (D, 2);
+%! assert (size (Y, 2), 1);
+%! assert (length (e), 2);
+%!test
+%! ## compatability with p
+%! X = rand (10, 4);
+%! D = pdist (X);
+%! [Y, e] = cmdscale (D, 3);
+%! assert (size (Y, 2), 3);
+%! assert (length (e), 3);
+%! assert (size (Y, 1), 10);
+%!error <cmdscale: input must be a numeric vector or matrix.> cmdscale ({'not', 'a', 'matrix'})
+%!error <matrix input must be square symmetric> cmdscale (rand (3, 4))
+%!error <entries must be nonnegative> cmdscale (-ones (3))
+%!error <p must be an integer> cmdscale (eye (3), 0)
+%!error <p must be an integer> cmdscale (eye (3), 4)
+%!error <p must be an integer> cmdscale (eye (3), 1.5)
+%!error <p must be an integer> cmdscale (eye (3), [1, 2])
+%!error <p must be an integer> cmdscale (eye (3), 2 + 1i)
 

--- a/inst/cmdscale.m
+++ b/inst/cmdscale.m
@@ -32,6 +32,12 @@
 ## of columns of @var{Y}, is equal to the number of positive real eigenvalues of
 ## @var{B}.
 ##
+## The optional argument @var{p} is a positive integer between 1 and @var{n}
+## that specifies the maximum dimensionality of the desired embedding @var{Y}.
+## If specified, @var{Y} will have at most @var{p} columns, and the returned
+## eigenvalues @var{e} will be a vector of exactly length @var{p}. Specifying
+## @var{p} can be useful for reducing dimensions for visualization (e.g., @code{@var{p} = 2}).
+##
 ## @var{D} can be a full or sparse matrix or a vector of length
 ## @code{@var{n}*(@var{n}-1)/2} containing the upper triangular elements (like
 ## the output of the @code{pdist} function). It must be symmetric with
@@ -108,30 +114,25 @@ function [Y, e] = cmdscale (D, p)
     D = sqrt (ones (n,n) - D);
   endif
 
-  ## Build centering matrix, perform double centering, extract eigenpairs
-  J = eye (n) - ones (n,n) / n;
+  ## Build centering matrix, perform double centering
+  J = eye (n) - ones (n, n) / n;
   B = -1 / 2 * J * (D .^ 2) * J;
+
+  B = (B + B') / 2;
+
+  ## extract and sort eigenpairs
   [Q, e] = eig (B);
-  e = diag (e);
-  etmp = e;
-  e = sort (e, 'descend');
-
-  ## Remove complex eigenpairs (only possible due to machine approximation)
-  if (iscomplex (etmp))
-    for i = 1 : size (etmp,1)
-      cmp(i) = (isreal (etmp(i)));
-    endfor
-    etmp = etmp(cmp);
-    Q = Q(:,cmp);
-  endif
-
-  ## Order eigenpairs
+  etmp = diag (e);
   [etmp, ord] = sort (etmp, 'descend');
-  Q = Q(:,ord);
+  Q = Q(:, ord);
 
   ## determine total strictly positive eigenvalues
   tol = n * max (abs (etmp)) * eps;
   n_pos = sum (etmp > tol);
+
+  if (n_pos == n)
+    n_pos = n - 1;
+  endif
 
   if (nargin > 1 && ! isempty (p))
     ## if p is given, eigenvalue output length is exactly p
@@ -140,10 +141,6 @@ function [Y, e] = cmdscale (D, p)
   else
     e = etmp;
     k = n_pos;
-    
-    if (k == n)
-      k = n - 1;
-    endif
   endif
 
   ## build output matrix Y by safely slicing the top k elements
@@ -151,16 +148,22 @@ function [Y, e] = cmdscale (D, p)
   Q = Q(:, 1:k);
   Y = Q * diag (sqrt (etmp));
 
+  [~, maxind] = max (abs (Y), [], 1);
+  d = size (Y, 2);
+  idx = maxind + (0 : n : (d - 1) * n);
+  colsign = sign (Y(idx));
+  colsign(colsign == 0) = 1; 
+  Y = Y .* colsign;
+
 endfunction
 
 %!test
-%!shared m, n, X, D
 %! m = randi (100) + 1;
 %! n = randi (100) + 1;
 %! X = rand (m, n);
 %! D = pdist (X);
-%!assert (norm (pdist (cmdscale (D))), norm (D), sqrt (eps))
-%!assert (norm (pdist (cmdscale (squareform (D)))), norm (D), sqrt (eps))
+%! assert (norm (pdist (cmdscale (D))), norm (D), sqrt (eps));
+%! assert (norm (pdist (cmdscale (squareform (D)))), norm (D), sqrt (eps));
 %!test
 %! ## basic dimentionality reduction
 %! D = [0 2 3; 2 0 4; 3 4 0];
@@ -189,6 +192,26 @@ endfunction
 %! assert (size (Y, 2), 3);
 %! assert (length (e), 3);
 %! assert (size (Y, 1), 10);
+%!test
+%! ## sign convention.
+%! rng (0, "twister");
+%! X = rand (10, 3);
+%! D = pdist (X);
+%! Y = cmdscale (D);
+%! [~, maxind] = max (abs (Y), [], 1);
+%! d = size (Y, 2);
+%! n = size (Y, 1);
+%! idx = maxind + (0 : n : (d - 1) * n);
+%! assert (all (Y(idx) >= 0));
+%!test
+%! ## testing with p = n and without p
+%! rng (1, "twister");
+%! X = rand (10, 4);
+%! D = pdist (X);
+%! n_points = size (X, 1);
+%! [Y1, e1] = cmdscale (D);
+%! [Y2, e2] = cmdscale (D, n_points);
+%! assert (size (Y1, 2), size (Y2, 2));
 %!error <cmdscale: input must be a numeric vector or matrix.> cmdscale ({'not', 'a', 'matrix'})
 %!error <matrix input must be square symmetric> cmdscale (rand (3, 4))
 %!error <entries must be nonnegative> cmdscale (-ones (3))

--- a/inst/cmdscale.m
+++ b/inst/cmdscale.m
@@ -110,7 +110,7 @@ function [Y, e] = cmdscale (D, p)
   if (any (any (D < 0)))
     error ("cmdscale: entries must be nonnegative.");
   elseif (trace (D) != 0)
-    if (!all (diag (D) == 1) || !all (D(:) <= 1))
+    if (! all (diag (D) == 1) || ! all (D(:) <= 1))
       error ("cmdscale: input must be a distance vector or matrix.");
     endif
     D = sqrt (ones (n,n) - D);
@@ -166,6 +166,28 @@ endfunction
 %! D = pdist (X);
 %! assert (norm (pdist (cmdscale (D))), norm (D), sqrt (eps));
 %! assert (norm (pdist (cmdscale (squareform (D)))), norm (D), sqrt (eps));
+%!test
+%! ## test output
+%! X = [
+%!   0.8147, 0.1576, 0.6557, 0.7060;
+%!   0.9058, 0.9706, 0.0357, 0.0318;
+%!   0.1270, 0.9572, 0.8491, 0.2769;
+%!   0.9134, 0.4854, 0.9340, 0.0462;
+%!   0.6324, 0.8003, 0.6787, 0.0971
+%! ];
+%! D = pdist (X);
+%! p = 2;
+%! [Y, e] = cmdscale (D, p);
+%! expected_Y = [
+%!    0.635444598081665, -0.209808014423477;
+%!   -0.558655450609184, -0.457908993032377;
+%!   -0.158680352453745,  0.622280326562354;
+%!    0.222509398493731, -0.047804408953240;
+%!   -0.140618193512467,  0.093241089846740
+%! ];
+%! expected_e = [0.810349112746116; 0.651912015993974];
+%! assert (Y, expected_Y, 1e-14);
+%! assert (e, expected_e, 1e-14);
 %!test
 %! ## basic dimentionality reduction
 %! D = [0 2 3; 2 0 4; 3 4 0];

--- a/inst/cmdscale.m
+++ b/inst/cmdscale.m
@@ -19,6 +19,8 @@
 ## -*- texinfo -*-
 ## @deftypefn  {statistics} {@var{Y} =} cmdscale (@var{D})
 ## @deftypefnx {statistics} {[@var{Y}, @var{e}] =} cmdscale (@var{D})
+## @deftypefnx {statistics} {@var{Y} =} cmdscale (@var{D}, @var{p})
+## @deftypefnx {statistics} {[@var{Y}, @var{e}] =} cmdscale (@var{D}, @var{p})
 ##
 ## Classical multidimensional scaling of a matrix.
 ##


### PR DESCRIPTION
1. Matlab also supports another `argument p` (dimensionality argument) which specifies the maximum dimension for output.
2. A sign convention block is also added at the end so that the largest absolute value in each `column` is always positive.
3. `Strict symmetry` on b matrix and hence removed the complex number check.
4. docs update
5. new BISTs