### PR TITLE
fix errors in `randsample`

### DIFF
--- a/inst/randsample.m
+++ b/inst/randsample.m
@@ -1,5 +1,6 @@
 ## Copyright (C) 2014 - Nir Krakauer
 ## Copyright (C) 2025 Andreas Bertsatos <abertsatos@biol.uoa.gr>
+## Copyright (C) 2026 Avanish Salunke <avanishsalunke16@gmail.com>
 ##
 ## This file is part of the statistics package for GNU Octave.
 ##
@@ -55,9 +56,13 @@ function y = randsample (v, k, replacement=false, w=[])
                    " integer. Sampling without replacement needs k <= n."));
   endif
 
-  if (all (length (w) != [0, n]))
-    error ("randsample: the size w (%d) must match the first argument (%d)", ...
-           length (w), n);
+  if (! isempty (w))
+    if (length (w) != n)
+      error ("randsample: the size w (%d) must match the first argument (%d)", ...
+             length (w), n);
+    elseif (! all (w >= 0) || sum (w) <= 0)
+      error ("randsample: the weight vector w must consist of non-negative elements and sum to a positive number");
+    endif
   endif
 
 
@@ -71,6 +76,9 @@ function y = randsample (v, k, replacement=false, w=[])
      if (isempty (w))            # all elements are equally likely to be sampled
        y = randperm (n, k);
      else                        # use "accept-reject"-like sampling
+       if (k > nnz (w))
+          error ("randsample: not enough non-zero weights for sampling without replacement");
+       endif
        y = weighted_replacement (k, w);
        while (1)
          [yy, idx] = sort (y);   # Note: sort keeps order of equal elements.
@@ -89,6 +97,13 @@ function y = randsample (v, k, replacement=false, w=[])
 
   if vector_v
     y = v(y);
+    if (iscolumn (v))
+      y = y(:);
+    elseif (isrow (v))
+      y = y(:).';
+    endif
+  else
+    y = y(:);
   endif
 
 endfunction
@@ -104,13 +119,13 @@ endfunction
 %! n = 20;
 %! k = 5;
 %! x = randsample(n, k);
-%! assert (size(x), [1 k]);
+%! assert (size(x), [k 1]);
 %! x = randsample(n, k, true);
-%! assert (size(x), [1 k]);
+%! assert (size(x), [k 1]);
 %! x = randsample(n, k, false);
-%! assert (size(x), [1 k]);
+%! assert (size(x), [k 1]);
 %! x = randsample(n, k, true, ones(n, 1));
-%! assert (size(x), [1 k]);
+%! assert (size(x), [k 1]);
 %! x = randsample(1:n, k);
 %! assert (size(x), [1 k]);
 %! x = randsample(1:n, k, true);
@@ -130,11 +145,11 @@ endfunction
 %! n = 10;
 %! k = 100;
 %! x = randsample(n, k, true, 1:n);
-%! assert (size(x), [1 k]);
+%! assert (size(x), [k 1]);
 %! x = randsample((1:n)', k, true);
 %! assert (size(x), [k 1]);
 %! x = randsample(k, k, false, 1:k);
-%! assert (size(x), [1 k]);
+%! assert (size(x), [k 1]);
 
 %!test
 %! n = 20;
@@ -207,3 +222,15 @@ endfunction
 
 %!error <randsample: the size w .* must match the first argument .*> ...
 %! randsample (10, 5, false, ones(5,1))
+
+%!error <the weight vector w must consist of non-negative elements> ...
+%! randsample (5, 2, true, [0, 0, 0, 0, 0])
+
+%!error <the weight vector w must consist of non-negative elements> ...
+%! randsample (5, 2, true, [1, 2, -1, 4, 5])
+
+%!error <the weight vector w must consist of non-negative elements> ...
+%! randsample (5, 2, true, [1, 2, NaN, 4, 5])
+
+%!error <not enough non-zero weights for sampling without replacement> ...
+%! randsample (5, 4, false, [1, 1, 0, 0, 0])

--- a/inst/randsample.m
+++ b/inst/randsample.m
@@ -51,10 +51,15 @@ function y = randsample (v, k, replacement=false, w=[])
     error ("randsample: The input v must be a vector or non-negative integer.");
   endif
 
-  if (! isscalar (k) || ! isnumeric (k) || k < 0 || round (k) != k || (k > n && ! replacement))
-    error (strcat ("randsample: The input k must be a non-negative", ...
-                   " integer. Sampling without replacement needs k <= n."));
+  if (! isscalar (k) || ! isnumeric (k) || round (k) != k)
+    error ("randsample: The input k must be an integer.");
   endif
+
+  if (max (0, k) > n && ! replacement)
+    error ("randsample: Sampling without replacement needs k <= n.");
+  endif
+
+  k = max (0, k);
 
   if (! isempty (w))
     if (length (w) != n)
@@ -217,11 +222,13 @@ endfunction
 %! assert (randsample (5.5, 1), 5.5);
 %! assert (randsample (-5, 1), -5);
 
+%!test
+%! x = randsample (10, -2);
+%! assert (isempty (x));
+%! assert (size (x), [0, 1]);
+
 %!error <randsample: The input v must be a vector or non-negative integer.> ...
 %! randsample ([1 2 3; 1 2 3], 5)
-
-%!error <randsample: The input k must be a non-negative integer.> ...
-%! randsample (10, -1)
 
 %!error <Sampling without replacement needs k <= n.> ...
 %! randsample (10, 100)
@@ -241,5 +248,5 @@ endfunction
 %!error <not enough non-zero weights for sampling without replacement> ...
 %! randsample (5, 4, false, [1, 1, 0, 0, 0])
 
-%!error <randsample: The input k must be a non-negative integer.> ...
+%!error <randsample: The input k must be an integer.> ...
 %! randsample (10, 2.5)

--- a/inst/randsample.m
+++ b/inst/randsample.m
@@ -41,17 +41,17 @@
 
 function y = randsample (v, k, replacement=false, w=[])
 
-  if (isscalar (v) && isreal (v))
+  if (isscalar (v) && isnumeric (v) && (round (v) == v) && (v >= 0))
     n = v;
     vector_v = false;
-  elseif (isvector (v))
+  elseif (isvector (v) || isscalar (v))
     n = length (v);
     vector_v = true;
   else
-    error ("randsample: The input v must be a vector or positive integer.");
+    error ("randsample: The input v must be a vector or non-negative integer.");
   endif
 
-  if k < 0 || ( k > n && !replacement )
+  if (! isscalar (k) || ! isnumeric (k) || k < 0 || round (k) != k || (k > n && ! replacement))
     error (strcat ("randsample: The input k must be a non-negative", ...
                    " integer. Sampling without replacement needs k <= n."));
   endif
@@ -211,7 +211,13 @@ endfunction
 %! assert (isstring(x));
 %! assert (size(x), [1 k]);
 
-%!error <randsample: The input v must be a vector or positive integer.> ...
+%!test
+%! assert (randsample ('A', 1), 'A');
+%! assert (randsample (true, 1), true);
+%! assert (randsample (5.5, 1), 5.5);
+%! assert (randsample (-5, 1), -5);
+
+%!error <randsample: The input v must be a vector or non-negative integer.> ...
 %! randsample ([1 2 3; 1 2 3], 5)
 
 %!error <randsample: The input k must be a non-negative integer.> ...
@@ -234,3 +240,6 @@ endfunction
 
 %!error <not enough non-zero weights for sampling without replacement> ...
 %! randsample (5, 4, false, [1, 1, 0, 0, 0])
+
+%!error <randsample: The input k must be a non-negative integer.> ...
+%! randsample (10, 2.5)


### PR DESCRIPTION
1. The output is a column vector when the input is a single scalar value.
matlab : 
```
>> n = 20;
>> k = 5;
>> x = randsample(n, k)

x =

     3
    20
    10
     4
    17
```
octave : 
```
octave:6> x = randsample(n, k)
x =

   10   19    7   17   12
```

2. The code use to go into infinite loop when the number of requested samples k exceeded the number of positive weights.
3. weight vector must be non-negative integer, not all zeros : 
matlab : 
```
>> randsample (5, 2, true, [0, 0, 0, 0, 0])
Error using randsample (line 98)
W must contain non-negative values with at least one positive value.
 

>> randsample (5, 2, true, [1, 2, -1, 4, 5])
Error using randsample (line 98)
W must contain non-negative values with at least one positive value.
```
octave : 
```
octave:7> randsample (5, 2, true, [0, 0, 0, 0, 0])
ans =

   1   1

octave:8> randsample (5, 2, true, [1, 2, -1, 4, 5])
ans =

   4   5
```
4. If k is negative it is treated as zero : 
matlab : 
```
>> randsample (10, -1)

ans =

  0×1 empty double column vector

>> randsample (10, 0)

ans =

  0×1 empty double column vector
```

5. treat v as a population size only when it is a positive integer : 
matlab : 
```
>> randsample ('A', 1)

ans =

    'A'
```
octave : 
```
octave:4> randsample ('A', 1)
warning: implicit conversion from numeric to char
warning: called from
    randsample at line 58 column 7

error: octave_base_value::int64_value (): wrong type argument 'sq_string'
error: called from
    randsample at line 72 column 8
```