### PR TITLE
fix `tabulate` to handle matrices.

### DIFF
--- a/inst/tabulate.m
+++ b/inst/tabulate.m
@@ -1,5 +1,6 @@
 ## Copyright (C) 2003 Alberto Terruzzi <t-albert@libero.it>
 ## Copyright (C) 2023 Andreas Bertsatos <abertsatos@biol.uoa.gr>
+## Copyright (C) 2026 Avanish Salunke <avanishsalunke16@gmail.com>
 ##
 ## This file is part of the statistics package for GNU Octave.
 ##
@@ -52,9 +53,9 @@
 function tbl = tabulate (x)
 
   ## Check input for being numeric, string, categorical, cell array or logical
-  if (! (isnumeric (x) && (isvector (x) || isempty (x))) && ! (iscellstr (x)
-                       && isvector (x)) && ! ischar (x) && ! iscategorical (x)
-                       && ! isa (x, "string") && ! islogical (x))
+  if (! ((isnumeric (x) || islogical (x) || ischar (x) || iscellstr (x) ...
+          || iscategorical (x) || isa (x, "string")) ...
+         && (ischar (x) || isvector (x) || isempty (x))))
     error (strcat ("tabulate: X must be either a numeric vector, a", ...
                    " vector cell array of strings, a character matrix,", ...
                    " a categorical array, or a string array."));
@@ -392,6 +393,12 @@ endfunction
 %!error<tabulate: X must be either a numeric vector> tabulate ({1, 2, 3, 4})
 %!error<tabulate: X must be either a numeric vector> ...
 %! tabulate ({"a", "b"; "a", "c"})
+%!error<tabulate: X must be either a numeric vector> ... 
+%! tabulate ([true, false; true, true])
+%!error<tabulate: X must be either a numeric vector> ...
+%! tabulate (string ({"a", "b"; "c", "d"}))
+%!error<tabulate: X must be either a numeric vector> ... 
+%! tabulate (categorical ({'a', 'b'; 'c', 'd'}))
 
 ## Test categorical with all undefined values (should return zero counts/percents)
 %!test
@@ -417,3 +424,13 @@ endfunction
 %! tbl = tabulate (x);
 %! assert (iscell (tbl));
 %! assert (isempty (tbl));
+
+## Test 2D character matrices.
+%!test
+%! x = ['yes'; 'no'; 'yes'];
+%! tbl = tabulate (x);
+%! assert (iscell (tbl));
+%! assert (size (tbl), [2, 3]);
+%! assert (tbl(:,1), {'yes'; 'no'});
+%! assert ([tbl{:,2}]', [2; 1]);
+%! assert ([tbl{:,3}]', [66.6667; 33.3333], 1e-4);

--- a/inst/tabulate.m
+++ b/inst/tabulate.m
@@ -1,6 +1,5 @@
 ## Copyright (C) 2003 Alberto Terruzzi <t-albert@libero.it>
 ## Copyright (C) 2023 Andreas Bertsatos <abertsatos@biol.uoa.gr>
-## Copyright (C) 2026 Avanish Salunke <avanishsalunke16@gmail.com>
 ##
 ## This file is part of the statistics package for GNU Octave.
 ##
@@ -53,8 +52,8 @@
 function tbl = tabulate (x)
 
   ## Check input for being numeric, string, categorical, cell array or logical
-  if (! ((isnumeric (x) || islogical (x) || ischar (x) || iscellstr (x) ...
-          || iscategorical (x) || isa (x, "string")) ...
+  if (! ((isnumeric (x) || islogical (x) || ischar (x) || iscellstr (x) 
+          || iscategorical (x) || isa (x, "string")) 
          && (ischar (x) || isvector (x) || isempty (x))))
     error (strcat ("tabulate: X must be either a numeric vector, a", ...
                    " vector cell array of strings, a character matrix,", ...


### PR DESCRIPTION
Some matrices(logical, string, categorical) passed even though they were not allowed.

before octave:
```
octave:4> tabulate ([true, false; true, true])
  2x3 table

    Value    Count    Percent    
    _____    _____    _______    

    {'0'}        1         25    
    {'1'}        3         75    

octave:5> tabulate (string ({"a", "b"; "c", "d"}))
  4x3 table

    Value    Count    Percent    
    _____    _____    _______    

    {'a'}        1         25    
    {'c'}        1         25    
    {'b'}        1         25    
    {'d'}        1         25    

octave:6> tabulate (categorical ({'a', 'b'; 'c', 'd'}))
  4x3 table

    Value    Count    Percent    
    _____    _____    _______    

    {'a'}        1         25    
    {'b'}        1         25    
    {'c'}        1         25    
    {'d'}        1         25    
```
1. modified the input block
2. added bists for it and character matrices.
