### PR TITLE
RegressionGAM.predict: correct ySD computation using residual variance

### DIFF
--- a/inst/Regression/RegressionGAM.m
+++ b/inst/Regression/RegressionGAM.m
@@ -881,6 +881,29 @@ endfunction
 %! assert (size (ySD), [4, 1]);
 %! assert (size (yInt), [4, 2]);
 
+%!test
+%! ## Verify ySD is based on training residual variance
+%! X = (1:10)';
+%! Y = [2; 1; 4; 3; 6; 5; 8; 7; 10; 9];
+%! mdl = RegressionGAM (X, Y);
+%! y_train = predict (mdl, X);
+%! rs = Y - y_train;
+%! expected_ySD = sqrt (var (rs));
+%! [~, ySD] = predict (mdl, X(1:4,:));
+%! assert (ySD, expected_ySD * ones (4, 1), 1e-10);
+
+%!test
+%! ## Verify ySD remains the same for one or more prediction points
+%! X = (1:10)';
+%! Y = [2; 1; 4; 3; 6; 5; 8; 7; 10; 9];
+%! mdl = RegressionGAM (X, Y);
+%! y_train = predict (mdl, X);
+%! expected_ySD = sqrt (var (Y - y_train));
+%! [~, ySD_1] = predict (mdl, X(1,:));
+%! [~, ySD_3] = predict (mdl, X(1:3,:));
+%! assert (ySD_1, expected_ySD, 1e-10);
+%! assert (ySD_3, expected_ySD * ones (3, 1), 1e-10);
+
 ## Test input validation for constructor
 %!error<RegressionGAM: too few input arguments.> RegressionGAM ()
 %!error<RegressionGAM: too few input arguments.> RegressionGAM (ones(10,2))

--- a/inst/Regression/RegressionGAM.m
+++ b/inst/Regression/RegressionGAM.m
@@ -556,12 +556,10 @@ classdef RegressionGAM
         ## Get the residuals between predicted and actual response data
         rs     = Y - yrs;
         var_rs = var (rs);
-        var_pr = var (yFit);  # var is calculated here instead take sqrt(SD)
 
         t_mul  = tinv (1 - alpha / 2, this.DoF);
 
-        ydev   = (yFit - mean (yFit)) .^ 2;
-        ySD    = sqrt (ydev / (rows (yFit) - 1));
+        ySD    = sqrt (var_rs) * ones (rows (yFit), 1);
 
         varargout{1} = ySD;
         if (nargout > 1)


### PR DESCRIPTION
Description:

- Replace incorrect prediction spread–based ySD calculation
- Use residual variance from training (var(Y - yrs))
- Return constant prediction standard deviation per observation
- Align prediction intervals with statistically valid formulation
- all BISTs pass