### PR TITLE
Fix double call in custom clustering evaluation

### DIFF
--- a/inst/Clustering/CalinskiHarabaszEvaluation.m
+++ b/inst/Clustering/CalinskiHarabaszEvaluation.m
@@ -158,8 +158,6 @@ classdef CalinskiHarabaszEvaluation < ClusterCriterion
                 error (strcat ("CalinskiHarabaszEvaluation: invalid return", ...
                                " value from custom clustering function."));
               endif
-              this.ClusteringSolutions(:, iter) = ...
-                this.ClusteringFunction(UsableX, this.InspectedK(iter));
             else
               switch (this.ClusteringFunction)
                 case "kmeans"
@@ -249,3 +247,17 @@ endclassdef
 %! load fisheriris
 %! eva = evalclusters (meas, "kmeans", "calinskiharabasz", "KList", [1:6]);
 %! assert (class (eva), "CalinskiHarabaszEvaluation");
+
+%!function C = count_calls_calinskiharabasz (X, k)
+%!  global count_calls_calinskiharabasz_n;
+%!  count_calls_calinskiharabasz_n += 1;
+%!  C = mod ((0 : rows (X) - 1)', k) + 1;
+%!endfunction
+%!test
+%! ## custom function must be called exactly once per inspected K
+%! global count_calls_calinskiharabasz_n;
+%! count_calls_calinskiharabasz_n = 0;
+%! evalclusters (rand (20, 2), @count_calls_calinskiharabasz, ...
+%!               "CalinskiHarabasz", "KList", [2, 3]);
+%! assert (count_calls_calinskiharabasz_n, 2);
+%! clear -global count_calls_calinskiharabasz_n;

--- a/inst/Clustering/GapEvaluation.m
+++ b/inst/Clustering/GapEvaluation.m
@@ -382,8 +382,6 @@ classdef GapEvaluation < ClusterCriterion
                   error (strcat ("GapEvaluation: invalid return value", ...
                                  " from custom clustering function"));
                 endif
-                this.ClusteringSolutions(:, iter) = ...
-                  this.ClusteringFunction(UsableX, this.InspectedK(iter));
               else
                 switch (this.ClusteringFunction)
                   case "kmeans"
@@ -496,3 +494,17 @@ endclassdef
 %! eva = evalclusters (meas([1:50],:), "kmeans", "gap", "KList", [1:3], ...
 %!                     "referencedistribution", "uniform");
 %! assert (class (eva), "GapEvaluation");
+
+%!function C = count_calls_gap (X, k)
+%!  global count_calls_gap_n;
+%!  count_calls_gap_n += 1;
+%!  C = mod ((0 : rows (X) - 1)', k) + 1;
+%!endfunction
+%!test
+%! ## custom function must be called exactly once per inspected K per run
+%! global count_calls_gap_n;
+%! count_calls_gap_n = 0;
+%! evalclusters (rand (20, 2), @count_calls_gap, "gap", ...
+%!               "KList", [2, 3], "B", 1);
+%! assert (count_calls_gap_n, 4);
+%! clear -global count_calls_gap_n;

--- a/inst/Clustering/GapEvaluation.m
+++ b/inst/Clustering/GapEvaluation.m
@@ -505,6 +505,6 @@ endclassdef
 %! global count_calls_gap_n;
 %! count_calls_gap_n = 0;
 %! evalclusters (rand (20, 2), @count_calls_gap, "gap", ...
-%!               "KList", [2, 3], "B", 1);
-%! assert (count_calls_gap_n, 4);
+%!               "KList", [2, 3], "B", 2);
+%! assert (count_calls_gap_n, 6);
 %! clear -global count_calls_gap_n;

--- a/inst/Clustering/GapEvaluation.m
+++ b/inst/Clustering/GapEvaluation.m
@@ -339,21 +339,21 @@ classdef GapEvaluation < ClusterCriterion
     ## evaluate
     ## do the evaluation
     function this = evaluate (this, K)
+      ## use complete observations only
+      ActualX = this.X(find (this.Missing == false), :);
+      colMins = min (ActualX);
+      colRange = max (ActualX) - colMins;
+
       ## Monte-Carlo runs
       for mcrun = 1 : (this.B + 1)
-        ## use complete observations only
-        UsableX = this.X(find (this.Missing == false), :);
-
         ## the last run use tha actual data,
         ## the others are Monte-Carlo runs with reconstructed data
         if (mcrun <= this.B)
           ## uniform distribution
-          colMins = min (UsableX);
-          colMaxs = max (UsableX);
-          for col = 1 : columns (UsableX)
-            UsableX(:, col) = colMins(col) + rand (this.NumObservations, 1) *...
-                              (colMaxs(col) - colMins(col));
-          endfor
+          UsableX = colMins + rand (this.NumObservations, columns (ActualX)) ...
+                    .* colRange;
+        else
+          UsableX = ActualX;
         endif
 
         if (! isempty (this.ClusteringFunction))

--- a/inst/Clustering/SilhouetteEvaluation.m
+++ b/inst/Clustering/SilhouetteEvaluation.m
@@ -298,8 +298,6 @@ classdef SilhouetteEvaluation < ClusterCriterion
                 error (strcat ("SilhouetteEvaluation: invalid return", ...
                                " value from custom clustering function."));
               endif
-              this.ClusteringSolutions(:, iter) = ...
-                this.ClusteringFunction(UsableX, this.InspectedK(iter));
             else
               switch (this.ClusteringFunction)
                 case "kmeans"
@@ -377,3 +375,17 @@ endclassdef
 %! load fisheriris
 %! eva = evalclusters (meas, "kmeans", "silhouette", "KList", [1:6]);
 %! assert (class (eva), "SilhouetteEvaluation");
+
+%!function C = count_calls_silhouette (X, k)
+%!  global count_calls_silhouette_n;
+%!  count_calls_silhouette_n += 1;
+%!  C = mod ((0 : rows (X) - 1)', k) + 1;
+%!endfunction
+%!test
+%! ## custom function must be called exactly once per inspected K
+%! global count_calls_silhouette_n;
+%! count_calls_silhouette_n = 0;
+%! evalclusters (rand (20, 2), @count_calls_silhouette, ...
+%!               "silhouette", "KList", [2, 3]);
+%! assert (count_calls_silhouette_n, 2);
+%! clear -global count_calls_silhouette_n;


### PR DESCRIPTION
Fixes a critical bug where custom clustering functions were called twice in clustering evaluation classes.

- Remove redundant second call that overwrote validated clustering output
- Add BIST coverage to ensure one call per inspected K (and per Monte Carlo run in Gap)
