### PR TITLE
signtest: replace length(find()) with sum() for counting

### DIFF
--- a/inst/signtest.m
+++ b/inst/signtest.m
@@ -201,7 +201,7 @@ function [p, h, stats] = signtest (x, my, varargin)
   endif
 
   ## Get the number of positive and negative elements from X-Y differences
-  pos_n = length (find (XY_diff > 0));
+  pos_n = sum (XY_diff > 0);
   neg_n = n - pos_n;
 
   ## Calculate stats according to selected method and tail


### PR DESCRIPTION
find allocates a full index vector (O(n) memory) just to get a count. sum on a logical vector does the same in one pass with zero allocation. All 23 BISTs pass.

<img width="1364" height="336" alt="image" src="https://github.com/user-attachments/assets/fed2c240-d257-4825-b548-69bd3467627d" />
