### PR TITLE
normalise_distribution: replace arrayfun identity with direct indexing

### DIFF
--- a/inst/normalise_distribution.m
+++ b/inst/normalise_distribution.m
@@ -172,8 +172,7 @@ function normalised = normalise_distribution (data, distribution, dimension)
       [ ignore, ignore, target_indices ] = unique ( data (:, k ) );
 
       ## Put normalised values in the places where they belong.
-      f_remap = @( k ) ( normal ( k ) );
-      normalised ( :, k ) = arrayfun ( f_remap, target_indices );
+      normalised ( :, k ) = normal (target_indices);
     endfor
   else
     ## With known distributions, everything boils down to a few lines of code


### PR DESCRIPTION
Removed a pointless `f_remap = @(k)(normal(k))` closure + arrayfun call, replaced with `normal(target_indices)` direct indexing.

<img width="1348" height="338" alt="image" src="https://github.com/user-attachments/assets/6a90e3b2-9d47-4eff-b444-09d25720da13" />
