### PR TITLE
stepwisefit: replace arrayfun(find) with ismember

### DIFF
--- a/inst/stepwisefit.m
+++ b/inst/stepwisefit.m
@@ -353,7 +353,7 @@ endif
       endfor
 
       ## Map removable predictors to positions within 'included'
-      removable_positions = arrayfun (@(x) find (included == x, 1), removable);
+      [~, removable_positions] = ismember (removable, included);
       [maxp, pos] = max (pvals_included(removable_positions));
 
       if (maxp > PRemove)


### PR DESCRIPTION
`arrayfun(find)` runs k separate O(p) linear scans. `ismember` does a single vectorized lookup. All 29 BISTs pass.