### PR TITLE
align term matrix sorting in Wilkinson Formula parser.

### DIFF
--- a/inst/parseWilkinsonFormula.m
+++ b/inst/parseWilkinsonFormula.m
@@ -836,7 +836,7 @@ function schema = run_schema_builder (expanded)
   [~, unique_idx] = unique (M, 'rows');
   terms_mat = terms_mat (unique_idx, :);
 
-  [~, sort_idx] = sortrows ([sum(terms_mat, 2), terms_mat]);
+  [~, sort_idx] = sortrows ([sum(terms_mat, 2), -terms_mat]);
   schema.Terms = terms_mat (sort_idx, :);
 
 endfunction
@@ -1659,6 +1659,12 @@ endfunction
 %! eq = parseWilkinsonFormula ('y ~ A - A', 'equation');
 %! expected = string('y = c1');
 %! assert (isequal (eq, expected));
+%!test
+%! ## Test : term row sorting.
+%! eq = parseWilkinsonFormula ('Y ~ x1 * x2 * x3', 'matrix');
+%! expected_terms = [0, 0, 0, 0; 0, 1, 0, 0; 0, 0, 1, 0; 0, 0, 0, 1; 0, 1, 1, 0; 0, 1, 0, 1; 0, 0, 1, 1; 0, 1, 1, 1];
+%! assert (eq.VariableNames, {'Y', 'x1', 'x2', 'x3'});
+%! assert (eq.Terms, expected_terms);
 %!error <Input formula string is required> parseWilkinsonFormula ()
 %!error <Unknown mode> parseWilkinsonFormula ('y ~ x', 'invalid_mode')
 %!error <Unexpected End Of Formula> parseWilkinsonFormula ('', 'parse')


### PR DESCRIPTION
> This issues was mentioned before as well in https://github.com/gnu-octave/statistics/issues/395

Standard `sortrows` on the binary terms matrix was sorting `0` before `1` because of this later variables (x3 - `0 0 1`) were evaluated before (x1- `1 0 0`).

Added negation so that instead of just comparing `0` and `1` it will compare `0` and `-1`.

MATLAB : 
```
>> formula = 'Y ~ x1 * x2 * x3';
>> mdl = fitlm(t, formula);
>> mdl.Formula.VariableNames

ans =

  1×4 cell array

    {'Y'}    {'x1'}    {'x2'}    {'x3'}

>> mdl.Formula.Terms

ans =

     0     0     0     0
     0     1     0     0
     0     0     1     0
     0     0     0     1
     0     1     1     0
     0     1     0     1
     0     0     1     1
     0     1     1     1
```
OCTAVE (before) : 
```
octave:5>  eq = parseWilkinsonFormula ('Y ~ x1 * x2 * x3', 'matrix');
octave:6> eq.VariableNames
ans =
  1x4 cell array

    {'Y'}    {'x1'}    {'x2'}    {'x3'}    

octave:7> eq.Terms
ans =

   0   0   0   0
   0   0   0   1
   0   0   1   0
   0   1   0   0
   0   0   1   1
   0   1   0   1
   0   1   1   0
   0   1   1   1
```

OCTAVE (after) : 
```
octave:5> eq = parseWilkinsonFormula ('Y ~ x1 * x2 * x3', 'matrix');
octave:6> eq.VariableNames
ans =
  1x4 cell array

    {'Y'}    {'x1'}    {'x2'}    {'x3'}    

octave:7> eq.Terms
ans =

   0   0   0   0
   0   1   0   0
   0   0   1   0
   0   0   0   1
   0   1   1   0
   0   1   0   1
   0   0   1   1
   0   1   1   1
```