### PR TITLE
fix power-term resolution from base table column in `parseWilkinsonFormula` function.

### DIFF
--- a/inst/parseWilkinsonFormula.m
+++ b/inst/parseWilkinsonFormula.m
@@ -852,15 +852,17 @@ function [X, y, col_names] = run_model_matrix_builder (schema, data)
     n_total = height (data);
     valid_mask = true (n_total, 1);
   else
-    if (! ismember (req_vars{1}, table_vars))
+    base0 = regexprep (req_vars{1}, '\^.*$', '');
+    if (! ismember (base0, table_vars))
       error ("parseWilkinsonFormula: Unknown variable '%s' in Data Table.", ...
              req_vars{1});
     endif
 
-    n_total = length (data.(req_vars{1}));
+    n_total = length (data.(base0));
     valid_mask = true (n_total, 1);
     for i = 1:length (req_vars)
-      col = data.(req_vars{i});
+      base_i = regexprep (req_vars{i}, '\^.*$', '');
+      col    = data.(base_i);
       if (isnumeric (col))
         valid_mask = valid_mask & ! isnan (col);
       endif
@@ -897,15 +899,26 @@ function [X, y, col_names] = run_model_matrix_builder (schema, data)
   ## Process predictors
   var_info = struct ();
   for i = 1:length (req_vars)
-    vname = req_vars{i};
-    raw = data.(vname);
+    vname    = req_vars{i};
+    hat_pos  = strfind (vname, '^');
+    if (! isempty (hat_pos))
+      base_name = vname(1:hat_pos(1)-1);
+      exp_val   = str2double (vname(hat_pos(1)+1:end));
+    else
+      base_name = vname;
+      exp_val   = 1;
+    endif
+    raw = data.(base_name);
 
     if (iscell (raw)), raw = raw(valid_mask);
     else, raw = raw(valid_mask, :); endif
 
     if (isnumeric (raw))
       var_info.(vname).type = 'numeric';
-      var_info.(vname).data = raw;
+      var_info.(vname).data = raw .^ exp_val;
+    elseif (exp_val != 1)
+      error (strcat ("parseWilkinsonFormula: Power operator '^' is", ...
+                     " only valid on numeric variables."));
     elseif (isa (raw, 'categorical'))
       var_info.(vname).type = 'categorical';
       var_info.(vname).levels = categories (raw);
@@ -1665,6 +1678,19 @@ endfunction
 %! expected_terms = [0, 0, 0, 0; 0, 1, 0, 0; 0, 0, 1, 0; 0, 0, 0, 1; 0, 1, 1, 0; 0, 1, 0, 1; 0, 0, 1, 1; 0, 1, 1, 1];
 %! assert (eq.VariableNames, {'Y', 'x1', 'x2', 'x3'});
 %! assert (eq.Terms, expected_terms);
+%!test
+%! ## Test : polynomial term Weight^2 resolves from base column not as table variable name
+%! Weight = [2000; 2500; 3000; 3500; 4000];
+%! MPG    = [30; 28; 25; 22; 18];
+%! d = table (Weight, MPG);
+%! [X, yout, names] = parseWilkinsonFormula ('MPG ~ Weight^2', 'model_matrix', d);
+%! assert (size (X), [5, 3]);
+%! assert (names{1}, '(Intercept)');
+%! assert (any (strcmp (names, 'Weight')));
+%! assert (any (strcmp (names, 'Weight^2')));
+%! w2i = find (strcmp (names, 'Weight^2'));
+%! assert (X(:, w2i), Weight .^ 2, 1e-10);
+%! assert (yout, MPG);
 %!error <Input formula string is required> parseWilkinsonFormula ()
 %!error <Unknown mode> parseWilkinsonFormula ('y ~ x', 'invalid_mode')
 %!error <Unexpected End Of Formula> parseWilkinsonFormula ('', 'parse')

--- a/inst/parseWilkinsonFormula.m
+++ b/inst/parseWilkinsonFormula.m
@@ -829,14 +829,22 @@ function schema = run_schema_builder (expanded)
     terms_mat(i, idx) = 1;
   endfor
 
-  ## sorting : order by order.
-  term_orders = sum (terms_mat, 2);
+  ## sorting : order by true polynomial degree, not raw presence count.
+  var_degree = ones (1, n_vars);
+  for v = 1:n_vars
+    tok = regexp (all_vars{v}, '\^(\d+)$', 'tokens');
+    if (! isempty (tok))
+      var_degree(v) = str2double (tok{1}{1});
+    endif
+  endfor
+
+  term_orders = terms_mat * var_degree';
   M = [term_orders, terms_mat];
 
   [~, unique_idx] = unique (M, 'rows');
   terms_mat = terms_mat (unique_idx, :);
 
-  [~, sort_idx] = sortrows ([sum(terms_mat, 2), -terms_mat]);
+  [~, sort_idx] = sortrows ([terms_mat * var_degree', -terms_mat]);
   schema.Terms = terms_mat (sort_idx, :);
 
 endfunction
@@ -1691,6 +1699,16 @@ endfunction
 %! w2i = find (strcmp (names, 'Weight^2'));
 %! assert (X(:, w2i), Weight .^ 2, 1e-10);
 %! assert (yout, MPG);
+%!test
+%! ## Test : squared term sorts after a categorical term
+%! Weight = [2000;2500;3000;3500;4000;4500;2200;2700;3200;3700;4200;4700];
+%! MPG    = [30;28;25;22;18;16;29;26;23;20;17;15];
+%! Year   = {'70';'70';'70';'70';'76';'76';'76';'76';'82';'82';'82';'82'};
+%! d = table (MPG, Weight, Year);
+%! [~, ~, n1] = parseWilkinsonFormula ('MPG ~ Year + Weight^2', 'model_matrix', d);
+%! [~, ~, n2] = parseWilkinsonFormula ('MPG ~ Weight^2 + Year', 'model_matrix', d);
+%! assert (n1, {'(Intercept)'; 'Weight'; 'Year_76'; 'Year_82'; 'Weight^2'});
+%! assert (n2, n1);
 %!error <Input formula string is required> parseWilkinsonFormula ()
 %!error <Unknown mode> parseWilkinsonFormula ('y ~ x', 'invalid_mode')
 %!error <Unexpected End Of Formula> parseWilkinsonFormula ('', 'parse')


### PR DESCRIPTION
Fixed `model_matrix` mode so that polynomial terms like `Weight^2` correctly resolve to the base table column `Weight` raised to that power, instead of looking for a literal (nonexistent) table variable named `Weight^2`.

this is part of https://github.com/gnu-octave/statistics/issues/266