### PR TITLE
anova: extend model support and performance

### DIFF
--- a/inst/Hypothesis_Testing/anova.m
+++ b/inst/Hypothesis_Testing/anova.m
@@ -2125,6 +2125,62 @@ endclassdef
 %! anova ([1;1;2;2], [1;2;3;4], 'CategoricalFactors', 1.5)
 %!error <anova: CategoricalFactors must contain valid factor indices.> ...
 %! anova ([1;1;2;2], [1;2;3;4], 'CategoricalFactors', 2)
+
+## --- Week 9: edge cases ------------------------------------------------
+
+%!test
+%! a = anova (ones (5, 1), (1:5)');
+%! T = stats (a);
+%! assert_equal (T{2, 3}, 0);
+%! assert_equal (T{2, 6}, NaN);
+%! a = anova (ones (5, 1), (1:5)', 'SumOfSquaresType', 'two');
+%! T = stats (a);
+%! assert_equal (T{2, 3}, 0);
+%! assert_equal (T{2, 6}, NaN);
+
+%!test
+%! a = anova (1, 7);
+%! T = stats (a);
+%! assert_equal (a.NumObservations, 1);
+%! assert_equal (T{2, 6}, NaN);
+
+%!test
+%! a = anova ([1; 1; 2; 2], ones (4, 1));
+%! T = stats (a);
+%! assert_equal (T{2, 2}, 0);
+%! assert_equal (T{2, 6}, 1);
+
+%!test
+%! g = categorical ([3; 3; 1; 1], [3, 2, 1]);
+%! a = anova (g, (1:4)');
+%! T = stats (a);
+%! assert_equal (isfinite (T{2, 6}), true);
+%! assert_equal (a.Stats.n, [2, 2]);
+%! assert_equal (a.Stats.gnames, {'3'; '1'});
+%! assert_equal (a.Stats.means, [1.5, 3.5]);
+%! a = anova (g, (1:4)', 'SumOfSquaresType', 'two');
+%! T = stats (a);
+%! assert_equal (T{2, 6}, 8, 1e-12);
+%! assert_equal (a.Stats.grpnames{1}, {'3'; '1'});
+
+%!test
+%! g = kron ((1:120)', ones (2, 1));
+%! a = anova (g, (1:240)');
+%! T = stats (a);
+%! assert_equal (T{2, 3}, 119);
+%! assert_equal (T{3, 3}, 120);
+
+%!test
+%! n = 128;
+%! group = cell (1, 6);
+%! for k = 1:6
+%!   group{k} = mod (floor ((0:n-1)' / 2^(k-1)), 2) + 1;
+%! endfor
+%! a = anova (group, (1:n)', 'ModelSpecification', 'full');
+%! stats (a);
+%! assert_equal (rows (a.Stats.terms), 63);
+%! assert_equal (columns (a.DesignMatrix), 64);
+
 %!error <anova: RandomFactors must contain positive integer indices.> ...
 %! anova ([1;1;2;2], [1;2;3;4], 'RandomFactors', 0)
 %!error <anova: RandomFactors indices exceed the number of factors.> ...

--- a/inst/Hypothesis_Testing/anova.m
+++ b/inst/Hypothesis_Testing/anova.m
@@ -429,21 +429,57 @@ classdef anova
     ## -*- texinfo -*-
     ## @deftypefn  {anova} {@var{s} =} stats (@var{obj})
     ## @deftypefnx {anova} {@var{s} =} stats (@var{obj}, @var{type})
+    ## @deftypefnx {anova} {@var{s} =} stats (@var{obj}, @qcode{"Component"}, @var{sstype})
+    ## @deftypefnx {anova} {[@var{s}, @var{ems}] =} stats (@dots{})
     ##
-    ## Return the fitted ANOVA table.
+    ## Return component or summary ANOVA statistics as a table.
     ##
-    ## The model is fitted first if needed.  The optional @var{type} argument
-    ## is accepted for MATLAB syntax compatibility; currently both
-    ## @qcode{'component'} and @qcode{'summary'} return the backend ANOVA
-    ## table.
+    ## With no @var{type}, or with @qcode{"component"}, return statistics for
+    ## each model term, error, and total.  With @qcode{"summary"}, group terms
+    ## into linear, nonlinear, and regression rows.  Replicated continuous
+    ## designs also report lack-of-fit and pure-error statistics.
+    ##
+    ## The @qcode{"Component"} form computes the component table using
+    ## @var{sstype}, which must be @qcode{"one"}, @qcode{"two"},
+    ## @qcode{"three"}, or @qcode{"hierarchical"}.  This request does not
+    ## change the object's read-only @code{SumOfSquaresType} property.
+    ## The second output @var{ems} contains expected mean-square information
+    ## for each model term and the error term.  Its variables are
+    ## @code{Type}, @code{ExpectedMeanSquares},
+    ## @code{MeanSquaresDenominator}, @code{DFDenominator}, and
+    ## @code{FDenominator}.
     ##
     ## @end deftypefn
-    function s = stats (obj, type)
-      if (nargin > 1 && ! obj.isName_ (type))
-        error ("anova.stats: type must be a character vector.");
+    function [s, ems] = stats (obj, varargin)
+      type = "component";
+      sstype = [];
+      if (numel (varargin) == 1)
+        type = varargin{1};
+      elseif (numel (varargin) == 2 && obj.isName_ (varargin{1}) ...
+              && strcmpi (varargin{1}, "component"))
+        sstype = obj.parseSSType_ (varargin{2});
+      elseif (! isempty (varargin))
+        error ("anova.stats: invalid input arguments.");
       endif
-      obj.ensureFit_ ();
-      s = obj.AnovaTable;
+      if (! obj.isName_ (type) ...
+          || ! any (strcmpi (type, {"component", "summary"})))
+        error ("anova.stats: type must be 'component' or 'summary'.");
+      endif
+      if (strcmpi (type, "summary"))
+        atab = obj.summaryStats_ ();
+      elseif (! isempty (sstype))
+        atab = obj.componentStats_ (sstype);
+      else
+        obj.ensureFit_ ();
+        atab = obj.AnovaTable;
+      endif
+      s = obj.statsTable_ (atab);
+      if (nargout > 1)
+        if (isempty (sstype))
+          sstype = obj.SSType;
+        endif
+        ems = obj.expectedMeanSquares_ (sstype);
+      endif
     endfunction
 
     ## -*- texinfo -*-
@@ -719,6 +755,28 @@ classdef anova
       endswitch
     endfunction
 
+    function value = parseSSType_ (obj, value)
+      if (isstring (value) && isscalar (value))
+        value = char (value);
+      endif
+      if (! ischar (value))
+        error ("anova.stats: component type must be a character vector.");
+      endif
+      switch (lower (value))
+        case "one"
+          value = 1;
+        case "two"
+          value = 2;
+        case "three"
+          value = 3;
+        case "hierarchical"
+          value = "h";
+        otherwise
+          error (strcat ("anova.stats: component type must be 'one',", ...
+                         " 'two', 'three', or 'hierarchical'."));
+      endswitch
+    endfunction
+
     function obj = setFactorNames_ (obj, value)
       if (isstring (value))
         value = cellstr (value(:))';
@@ -750,7 +808,7 @@ classdef anova
 
     function obj = setFormula_ (obj)
       if (isempty (obj.FactorNames))
-        obj.FactorNames = arrayfun (@(k) sprintf ("X%d", k), ...
+        obj.FactorNames = arrayfun (@(k) sprintf ("Factor%d", k), ...
                                     1:obj.nFactors_, ...
                                     'UniformOutput', false);
         obj.VarNames = obj.FactorNames;
@@ -845,7 +903,7 @@ classdef anova
       if (idx >= 1 && idx <= numel (obj.FactorNames))
         name = obj.FactorNames{idx};
       else
-        name = sprintf ("X%d", idx);
+        name = sprintf ("Factor%d", idx);
       endif
     endfunction
 
@@ -928,6 +986,214 @@ classdef anova
       tbl = table (mse, sqrt (max (mse, 0)), sse, ssr, sst, rsq, adj, ...
                    'VariableNames', {'MSE', 'RMSE', 'SSE', 'SSR', 'SST', ...
                                      'RSquared', 'AdjustedRSquared'});
+    endfunction
+
+    function out = statsTable_ (obj, atab)
+      if (isempty (atab))
+        out = table ([], [], [], [], [], "VariableNames", ...
+                     {"SumOfSquares", "DF", "MeanSquares", "F", "pValue"});
+        return;
+      endif
+      source_col = obj.findAtabColumn_ (atab, {"Source"});
+      columns = {{"SumOfSquares", "Sum Sq.", "Sum Sq", "SS"}, ...
+                 {"DF", "d.f.", "df"}, ...
+                 {"MeanSquares", "Mean Sq.", "Mean Sq", "MS"}, ...
+                 {"F"}, {"pValue", "Prob>F"}};
+      names = {"SumOfSquares", "DF", "MeanSquares", "F", "pValue"};
+      n = rows (atab) - 1;
+      values = cell (1, numel (columns));
+      for j = 1:numel (columns)
+        col = obj.findAtabColumn_ (atab, columns{j});
+        values{j} = NaN (n, 1);
+        for i = 1:n
+          value = atab{i + 1, col};
+          if (isnumeric (value) && isscalar (value) && ! isempty (value))
+            values{j}(i) = value;
+          endif
+        endfor
+      endfor
+      row_names = obj.publicSourceNames_ (atab(2:end, source_col));
+      out = table (values{:}, "VariableNames", names, "RowNames", row_names);
+    endfunction
+
+    function ems = expectedMeanSquares_ (obj, sstype)
+      obj.ensureFit_ ();
+      if (strcmp (obj.backend_, "linearmodel"))
+        error (strcat ("anova.stats: expected mean squares are unavailable", ...
+                       " for LinearModel input."));
+      endif
+
+      atab = obj.componentStats_ (sstype);
+      sources = obj.publicSourceNames_ (atab(2:end-1, 1));
+      nterms = numel (sources) - 1;
+      term_names = sources(1:nterms);
+      is_random = false (nterms, 1);
+      q_coeff = ones (nterms, 1);
+      variance_coeff = zeros (nterms, nterms);
+
+      if (strcmp (obj.backend_, "anovan") && isfield (obj.Stats, "terms"))
+        terms = obj.Stats.terms;
+        if (! isempty (obj.RandomFactors))
+          is_random = any (terms(:, obj.RandomFactors), 2);
+        endif
+        [q_coeff, variance_coeff] = obj.emsCoefficients_ (terms, sstype, ...
+                                                          is_random);
+      elseif (strcmp (obj.backend_, "anova1"))
+        [q_coeff(1), variance_coeff(1, 1)] = obj.oneWayEmsCoefficient_ ();
+        is_random(1) = any (obj.RandomFactors == 1);
+      endif
+
+      formulas = cell (nterms + 1, 1);
+      types = repmat ({"fixed"}, nterms + 1, 1);
+      for i = 1:nterms
+        pieces = {};
+        if (is_random(i))
+          types{i} = "random";
+        else
+          term = obj.emsTerm_ (q_coeff(i), "Q", term_names{i});
+          if (! isempty (term))
+            pieces{end + 1} = term;
+          endif
+        endif
+        for j = find (is_random(:))'
+          if (abs (variance_coeff(i, j)) > 1e-10)
+            pieces{end + 1} = obj.emsTerm_ (variance_coeff(i, j), ...
+                                            "V", term_names{j});
+          endif
+        endfor
+        pieces{end + 1} = "V(Error)";
+        formulas{i} = strjoin (pieces, "+");
+      endfor
+      types{end} = "random";
+      formulas{end} = "V(Error)";
+
+      denominator_ms = [repmat(obj.MSE, nterms, 1); NaN];
+      denominator_df = [repmat(obj.DFE, nterms, 1); NaN];
+      denominator_formula = [repmat({"MS(Error)"}, nterms, 1); {""}];
+      row_names = [term_names; {"Error"}];
+      ems = table (string (types), string (formulas), denominator_ms, ...
+                   denominator_df, string (denominator_formula), ...
+                   "VariableNames", {"Type", "ExpectedMeanSquares", ...
+                   "MeanSquaresDenominator", "DFDenominator", ...
+                   "FDenominator"}, "RowNames", row_names);
+    endfunction
+
+    function names = publicSourceNames_ (obj, names)
+      names = regexprep (names, "'$", "");
+      names = regexprep (names, "\\*", ":");
+      if (strcmp (obj.backend_, "anova1") && ! isempty (names))
+        idx = find (strcmpi (names, "Groups"), 1);
+        if (! isempty (idx))
+          names{idx} = obj.FactorNames{1};
+        endif
+      elseif (strcmp (obj.backend_, "anova2"))
+        idx = find (strcmpi (names, "Columns"), 1);
+        if (! isempty (idx))
+          names{idx} = obj.FactorNames{1};
+        endif
+        idx = find (strcmpi (names, "Rows"), 1);
+        if (! isempty (idx))
+          names{idx} = obj.FactorNames{2};
+        endif
+        idx = find (strcmpi (names, "Interaction"), 1);
+        if (! isempty (idx))
+          names{idx} = sprintf ("%s:%s", obj.FactorNames{:});
+        endif
+      endif
+    endfunction
+
+    function [q_coeff, variance_coeff] = emsCoefficients_ (obj, terms, ...
+                                                           sstype, is_random)
+      X = full (obj.Stats.X);
+      dfs = obj.Stats.df(:);
+      nterms = rows (terms);
+      blocks = cell (nterms, 1);
+      first = 2;
+      for i = 1:nterms
+        blocks{i} = first:first + dfs(i) - 1;
+        first += dfs(i);
+      endfor
+      bases = cell (nterms, 1);
+      for i = 1:nterms
+        factors = find (terms(i, :));
+        if (all (! ismember (factors, obj.Continuous)))
+          [~, ~, ids] = unique (obj.Stats.grps(:, factors), "rows");
+          bases{i} = sparse (1:numel (ids), ids, 1);
+        else
+          bases{i} = X(:, blocks{i});
+        endif
+      endfor
+
+      q_coeff = zeros (nterms, 1);
+      variance_coeff = zeros (nterms, nterms);
+      for i = 1:nterms
+        [included, excluded] = obj.emsModels_ (X, blocks, terms, i, sstype);
+        q_coeff(i) = obj.projectionDifference_ (included, excluded, ...
+                                                bases{i}) / dfs(i);
+        for j = find (is_random(:))'
+          variance_coeff(i, j) = obj.projectionDifference_ (...
+                                  included, excluded, bases{j}) / dfs(i);
+        endfor
+      endfor
+    endfunction
+
+    function [included, excluded] = emsModels_ (obj, X, blocks, terms, ...
+                                                term, sstype)
+      nterms = numel (blocks);
+      switch (sstype)
+        case 1
+          included_terms = 1:term;
+          excluded_terms = 1:term-1;
+        case {2, "h"}
+          factors = find (terms(term, :));
+          excluded_terms = find (any (! terms(:, factors), 2))';
+          included_terms = [term, excluded_terms];
+        otherwise
+          included_terms = 1:nterms;
+          excluded_terms = setdiff (included_terms, term, "stable");
+      endswitch
+      included = X(:, [1, blocks{included_terms}]);
+      excluded = X(:, [1, blocks{excluded_terms}]);
+    endfunction
+
+    function value = projectionDifference_ (obj, included, excluded, basis)
+      value = obj.projectionEnergy_ (included, basis) ...
+              - obj.projectionEnergy_ (excluded, basis);
+      value = max (value, 0);
+    endfunction
+
+    function value = projectionEnergy_ (obj, design, basis)
+      Q = orth (full (design));
+      value = sum (sumsq (Q' * basis));
+    endfunction
+
+    function [q_coeff, variance_coeff] = oneWayEmsCoefficient_ (obj)
+      if (isvector (obj.Y))
+        group = obj.GROUP(:);
+      else
+        [n, groups] = size (obj.Y);
+        group = reshape (repmat (1:groups, n, 1), [], 1);
+      endif
+      [~, ~, ids] = unique (group, "stable");
+      Z = sparse (1:numel (ids), ids, 1);
+      intercept = ones (rows (Z), 1);
+      df = columns (Z) - 1;
+      if (df == 0)
+        q_coeff = 0;
+      else
+        q_coeff = obj.projectionDifference_ (Z, intercept, Z) / df;
+      endif
+      variance_coeff = q_coeff;
+    endfunction
+
+    function value = emsTerm_ (obj, coefficient, symbol, name)
+      if (! isfinite (coefficient) || abs (coefficient) <= 1e-10)
+        value = "";
+      elseif (abs (coefficient - 1) <= 1e-10)
+        value = sprintf ("%s(%s)", symbol, name);
+      else
+        value = sprintf ("%.6g*%s(%s)", coefficient, symbol, name);
+      endif
     endfunction
 
     function obj = initLinearModel_ (obj, mdl, varargin)
@@ -1183,20 +1449,7 @@ classdef anova
     endfunction
 
     function obj = fitAnovan_ (obj)
-      ## Unroll a matrix Y with no GROUP into a vector + synthetic
-      ## column index — needed for the anova1-matrix-form fallback.
-      if (isempty (obj.GROUP) && ! isvector (obj.Y))
-        [n, m] = size (obj.Y);
-        y_vec  = obj.Y(:);
-        g_vec  = reshape (repmat ((1:m), n, 1), [], 1);
-        group_arg = {g_vec};
-      else
-        y_vec = obj.Y(:);
-        group_arg = obj.GROUP;
-        if (isempty (group_arg))
-          group_arg = {};
-        endif
-      endif
+      [y_vec, group_arg] = obj.anovanData_ ();
       [~, atab, stats] = anovan (y_vec, group_arg, ...
                                  obj.buildAnovanArgs_(){:});
       obj.AnovaTable = atab;
@@ -1240,6 +1493,116 @@ classdef anova
       endif
     endfunction
 
+    function atab = componentStats_ (obj, sstype)
+      if (strcmp (obj.backend_, "linearmodel"))
+        error ("anova.stats: component type is unavailable for LinearModel input.");
+      endif
+      if (strcmp (obj.backend_, "anova2"))
+        obj.ensureFit_ ();
+        atab = obj.AnovaTable;
+        return;
+      endif
+      [y_vec, group_arg] = obj.anovanData_ ();
+      args = obj.buildAnovanArgs_ (sstype);
+      [~, atab] = anovan (y_vec, group_arg, args{:});
+    endfunction
+
+    function atab = summaryStats_ (obj)
+      obj.ensureFit_ ();
+      component = obj.componentStats_ (1);
+      sources = component(2:end, 1);
+      error_idx = find (strcmpi (sources, "Error"), 1);
+      total_idx = find (strcmpi (sources, "Total"), 1);
+      term_idx = setdiff (1:numel (sources), [error_idx, total_idx], "stable");
+      term_ss = cell2mat (component(term_idx + 1, 2));
+      term_df = cell2mat (component(term_idx + 1, 3));
+
+      if (strcmp (obj.backend_, "anova2"))
+        nonlinear = strcmpi (sources(term_idx), "Interaction");
+      elseif (isfield (obj.Stats, "terms") ...
+              && rows (obj.Stats.terms) == numel (term_idx))
+        nonlinear = (sum (obj.Stats.terms, 2) > 1);
+      else
+        nonlinear = ! cellfun (@isempty, regexp (sources(term_idx), "[:*]"));
+      endif
+      linear = ! nonlinear;
+
+      labels = {};
+      sum_sq = [];
+      df = [];
+      if (any (linear))
+        labels{end + 1, 1} = "Linear";
+        sum_sq(end + 1, 1) = sum (term_ss(linear));
+        df(end + 1, 1) = sum (term_df(linear));
+      endif
+      if (any (nonlinear))
+        labels{end + 1, 1} = "NonLinear";
+        sum_sq(end + 1, 1) = sum (term_ss(nonlinear));
+        df(end + 1, 1) = sum (term_df(nonlinear));
+      endif
+      labels{end + 1, 1} = "Regression";
+      sum_sq(end + 1, 1) = sum (term_ss);
+      df(end + 1, 1) = sum (term_df);
+      tested_rows = numel (labels);
+
+      error_ss = component{error_idx + 1, 2};
+      error_df = component{error_idx + 1, 3};
+      labels{end + 1, 1} = "Error";
+      sum_sq(end + 1, 1) = error_ss;
+      df(end + 1, 1) = error_df;
+      error_row = numel (labels);
+
+      lack_row = [];
+      if (strcmp (obj.backend_, "anovan") && isempty (obj.Weights) ...
+          && isfield (obj.Stats, "grps") && isfield (obj.Stats, "Y"))
+        [~, ~, group_id] = unique (obj.Stats.grps, "rows");
+        group_mean = accumarray (group_id, obj.Stats.Y, [], @mean);
+        pure_ss = sum ((obj.Stats.Y - group_mean(group_id)) .^ 2);
+        pure_df = numel (obj.Stats.Y) - max (group_id);
+        lack_df = error_df - pure_df;
+        if (pure_df > 0 && lack_df > 0)
+          labels(end + 1:end + 2, 1) = {"LackOfFit"; "PureError"};
+          sum_sq(end + 1:end + 2, 1) = [max(error_ss - pure_ss, 0); pure_ss];
+          df(end + 1:end + 2, 1) = [lack_df; pure_df];
+          lack_row = numel (labels) - 1;
+        endif
+      endif
+
+      labels{end + 1, 1} = "Total";
+      sum_sq(end + 1, 1) = component{total_idx + 1, 2};
+      df(end + 1, 1) = component{total_idx + 1, 3};
+      mean_sq = sum_sq ./ df;
+      mse = mean_sq(error_row);
+      f_stat = mean_sq(1:tested_rows) ./ mse;
+      p_value = fcdf (f_stat, df(1:tested_rows), error_df, "upper");
+
+      atab = cell (numel (labels) + 1, 6);
+      atab(1, :) = {"Source", "Sum Sq.", "d.f.", "Mean Sq.", "F", "Prob>F"};
+      atab(2:end, 1) = labels;
+      atab(2:end, 2:4) = num2cell ([sum_sq, df, mean_sq]);
+      atab(2:tested_rows + 1, 5:6) = num2cell ([f_stat, p_value]);
+      if (! isempty (lack_row))
+        lack_f = mean_sq(lack_row) / mean_sq(lack_row + 1);
+        lack_p = fcdf (lack_f, df(lack_row), df(lack_row + 1), "upper");
+        atab(lack_row + 1, 5:6) = {lack_f, lack_p};
+      endif
+    endfunction
+
+    function [y_vec, group_arg] = anovanData_ (obj)
+      if (isempty (obj.GROUP) && ! isvector (obj.Y))
+        [n, m] = size (obj.Y);
+        y_vec = obj.Y(:);
+        group = reshape (repmat (1:m, n, 1), [], 1);
+        group_arg = {group};
+      else
+        y_vec = obj.Y(:);
+        group_arg = obj.GROUP;
+        if (isempty (group_arg))
+          group_arg = {};
+        endif
+      endif
+    endfunction
+
     function s = sstypeLabel_ (obj)
       switch (obj.SSType)
         case 1; s = 'I';
@@ -1276,11 +1639,12 @@ classdef anova
       endfor
     endfunction
 
-    function nv = buildAnovanArgs_ (obj)
-      ## Always run the anovan backend silently; anova presents results through
-      ## its own summary, disp, and plotDiagnostics methods, so the backend must
-      ## not print a table or open its diagnostic-plots figure during a fit.
-      nv = {'display', 'off', 'sstype', obj.SSType, 'alpha', obj.Alpha};
+    function nv = buildAnovanArgs_ (obj, sstype)
+      if (nargin < 2)
+        sstype = obj.SSType;
+      endif
+      ## Run the backend silently; this class owns display and plotting.
+      nv = {'display', 'off', 'sstype', sstype, 'alpha', obj.Alpha};
       if (ischar (obj.ModelType) || isnumeric (obj.ModelType))
         if (! (isnumeric (obj.ModelType) && isempty (obj.ModelType)))
           nv = [nv, {'model', obj.ModelType}];
@@ -1614,7 +1978,7 @@ endclassdef
 %! assert_equal (a.ModelSpecification, 'linear');
 %! assert_equal (a.SumOfSquaresType, 'three');
 %! assert_equal (a.ResponseName, 'Y');
-%! assert_equal (a.FactorNames, {'X1'});
+%! assert_equal (a.FactorNames, {'Factor1'});
 %! assert_equal (a.RandomFactors, []);
 %! assert_equal (a.CategoricalFactors, 'all');
 %! assert_equal (a.NumFactors, 1);
@@ -1804,9 +2168,9 @@ endclassdef
 %! a = anova (g, y, 'SumOfSquaresType', 'two');
 %! a.fit ();
 %! T = a.AnovaTable;
-%! assert_equal (T{2, 2}, 126, 1e-12);       # group SS
-%! assert_equal (T{3, 2}, 6, 1e-12);         # error SS
-%! assert_equal (T{4, 2}, 132, 1e-12);       # total SS
+%! assert_equal (T{2, 2}, 126, 1e-12);
+%! assert_equal (T{3, 2}, 6, 1e-12);
+%! assert_equal (T{4, 2}, 132, 1e-12);
 %! assert_equal (T{2, 3}, 2);
 %! assert_equal (T{3, 3}, 6);
 %! assert_equal (T{2, 4}, 63, 1e-12);
@@ -1829,7 +2193,7 @@ endclassdef
 %! y = [1; 2; 3; 4; 5; 6; 10; 11; 12];
 %! g = [1; 1; 1; 2; 2; 2; 3; 3; 3];
 %! es = getEffectSizes (anova (g, y, 'SumOfSquaresType', 'two'));
-%! assert_equal (es.Source, {'X1'});
+%! assert_equal (es.Source, {'Factor1'});
 %! assert_equal (es.EtaSquared, 126 / 132, 1e-12);
 %! assert_equal (es.PartialEtaSquared, 126 / (126 + 6), 1e-12);
 %! assert_equal (es.OmegaSquared, 124 / 133, 1e-12);
@@ -1936,7 +2300,7 @@ endclassdef
 %! T = stats (a);
 %! M = groupmeans (a);
 %! V = varianceComponent (a);
-%! assert_equal (T{2, 2}, 126, 1e-12);
+%! assert_equal (T.SumOfSquares(1), 126, 1e-12);
 %! assert_equal (M.Mean, [2; 5; 11], 1e-12);
 %! assert_equal (V.VarianceComponent, 1, 1e-12);
 
@@ -2130,45 +2494,47 @@ endclassdef
 
 %!test
 %! a = anova (ones (5, 1), (1:5)');
-%! T = stats (a);
-%! assert_equal (T{2, 3}, 0);
-%! assert_equal (T{2, 6}, NaN);
+%! [T, ems] = stats (a);
+%! assert_equal (T.DF(1), 0);
+%! assert_equal (T.pValue(1), NaN);
+%! assert_equal (cellstr (ems.ExpectedMeanSquares), ...
+%!               {'V(Error)'; 'V(Error)'});
 %! a = anova (ones (5, 1), (1:5)', 'SumOfSquaresType', 'two');
 %! T = stats (a);
-%! assert_equal (T{2, 3}, 0);
-%! assert_equal (T{2, 6}, NaN);
+%! assert_equal (T.DF(1), 0);
+%! assert_equal (T.pValue(1), NaN);
 
 %!test
 %! a = anova (1, 7);
 %! T = stats (a);
 %! assert_equal (a.NumObservations, 1);
-%! assert_equal (T{2, 6}, NaN);
+%! assert_equal (T.pValue(1), NaN);
 
 %!test
 %! a = anova ([1; 1; 2; 2], ones (4, 1));
 %! T = stats (a);
-%! assert_equal (T{2, 2}, 0);
-%! assert_equal (T{2, 6}, 1);
+%! assert_equal (T.SumOfSquares(1), 0);
+%! assert_equal (T.pValue(1), 1);
 
 %!test
 %! g = categorical ([3; 3; 1; 1], [3, 2, 1]);
 %! a = anova (g, (1:4)');
 %! T = stats (a);
-%! assert_equal (isfinite (T{2, 6}), true);
+%! assert_equal (isfinite (T.pValue(1)), true);
 %! assert_equal (a.Stats.n, [2, 2]);
 %! assert_equal (a.Stats.gnames, {'3'; '1'});
 %! assert_equal (a.Stats.means, [1.5, 3.5]);
 %! a = anova (g, (1:4)', 'SumOfSquaresType', 'two');
 %! T = stats (a);
-%! assert_equal (T{2, 6}, 8, 1e-12);
+%! assert_equal (T.F(1), 8, 1e-12);
 %! assert_equal (a.Stats.grpnames{1}, {'3'; '1'});
 
 %!test
 %! g = kron ((1:120)', ones (2, 1));
 %! a = anova (g, (1:240)');
 %! T = stats (a);
-%! assert_equal (T{2, 3}, 119);
-%! assert_equal (T{3, 3}, 120);
+%! assert_equal (T.DF(1), 119);
+%! assert_equal (T.DF(2), 120);
 
 %!test
 %! n = 128;
@@ -2180,6 +2546,192 @@ endclassdef
 %! stats (a);
 %! assert_equal (rows (a.Stats.terms), 63);
 %! assert_equal (columns (a.DesignMatrix), 64);
+
+## --- Week 10: configuration integration -------------------------------
+
+%!test
+%! y = [1; 2; 3; 4; 5; 6; 10; 11; 12];
+%! g = [1; 1; 1; 2; 2; 2; 3; 3; 3];
+%! a = anova (g, y, 'FactorNames', {'Treatment'});
+%! [component, ems] = stats (a);
+%! assert_equal (istable (component), true);
+%! assert_equal (component.Properties.VariableNames, ...
+%!               {'SumOfSquares', 'DF', 'MeanSquares', 'F', 'pValue'});
+%! assert_equal (component.Properties.RowNames, ...
+%!               {'Treatment'; 'Error'; 'Total'});
+%! assert_equal (component.SumOfSquares, [126; 6; 132], 1e-12);
+%! assert_equal (istable (ems), true);
+%! assert_equal (ems.Properties.VariableNames, ...
+%!               {'Type', 'ExpectedMeanSquares', 'MeanSquaresDenominator', ...
+%!                'DFDenominator', 'FDenominator'});
+%! assert_equal (ems.Properties.RowNames, {'Treatment'; 'Error'});
+%! assert_equal (cellstr (ems.Type), {'fixed'; 'random'});
+%! assert_equal (cellstr (ems.ExpectedMeanSquares), ...
+%!               {'3*Q(Treatment)+V(Error)'; 'V(Error)'});
+%! assert_equal (ems.MeanSquaresDenominator, [1; NaN]);
+%! assert_equal (ems.DFDenominator, [6; NaN]);
+%! assert_equal (cellstr (ems.FDenominator), {'MS(Error)'; ''});
+
+%!test
+%! y = [1; 2; 3; 4; 5; 6; 10; 11; 12];
+%! g = [1; 1; 1; 2; 2; 2; 3; 3; 3];
+%! a = anova (g, y, 'FactorNames', {'Treatment'}, 'RandomFactors', 1);
+%! [~, ems] = stats (a);
+%! assert_equal (cellstr (ems.Type), {'random'; 'random'});
+%! assert_equal (cellstr (ems.ExpectedMeanSquares), ...
+%!               {'3*V(Treatment)+V(Error)'; 'V(Error)'});
+
+%!test
+%! y = [5.5, 4.5, 3.5; 5.5, 4.5, 4.0; 6.0, 4.0, 3.0; ...
+%!      6.5, 5.0, 4.0; 7.0, 5.5, 5.0; 7.0, 5.0, 4.5];
+%! a = anova (y, [], 'Reps', 3, 'ModelSpecification', 'interactions', ...
+%!            'FactorNames', {'Brand', 'PopperType'});
+%! component = stats (a);
+%! assert_equal (component.Properties.RowNames, ...
+%!               {'Brand'; 'PopperType'; 'Brand:PopperType'; 'Error'; 'Total'});
+
+%!function values = __anova_values__ (tbl)
+%!  if (istable (tbl))
+%!    values = [tbl.SumOfSquares, tbl.DF, tbl.MeanSquares, tbl.F, tbl.pValue];
+%!    return;
+%!  endif
+%!  if (columns (tbl) == 6)
+%!    columns_ = [2, 3, 4, 5, 6];
+%!  else
+%!    columns_ = [2, 3, 4, 6, 7];
+%!  endif
+%!  values = NaN (rows (tbl) - 1, numel (columns_));
+%!  for i = 2:rows (tbl)
+%!    for j = 1:numel (columns_)
+%!      value = tbl{i, columns_(j)};
+%!      if (isnumeric (value) && isscalar (value))
+%!        values(i - 1, j) = value;
+%!      endif
+%!    endfor
+%!  endfor
+%!endfunction
+
+%!test
+%! y = [24; 26; 25; 24; 15; 17; 20; 16; 25; 29; 27; 19; 18; 21; 20];
+%! gender = [1; 1; 1; 1; 1; 1; 1; 1; 2; 2; 2; 2; 2; 2; 2];
+%! degree = [1; 1; 1; 1; 0; 0; 0; 0; 1; 1; 1; 0; 0; 0; 0];
+%! a = anova ({gender, degree}, y, 'ModelSpecification', 'full');
+%! component = stats (a, 'component', 'one');
+%! [~, expected] = anovan (y, {gender, degree}, 'model', 'full', ...
+%!                         'sstype', 1, 'display', 'off');
+%! assert_equal (component.Properties.RowNames, ...
+%!               {'Factor1'; 'Factor2'; 'Factor1:Factor2'; 'Error'; 'Total'});
+%! assert_equal (__anova_values__ (component), ...
+%!               __anova_values__ (expected), 1e-10);
+%! assert_equal (a.SumOfSquaresType, 'three');
+%! assert_equal (istable (stats (a)), true);
+
+%!test
+%! y = [5.5, 4.5, 3.5; 5.5, 4.5, 4.0; 6.0, 4.0, 3.0; ...
+%!      6.5, 5.0, 4.0; 7.0, 5.5, 5.0; 7.0, 5.0, 4.5];
+%! a = anova (y, [], 'Reps', 3, 'ModelSpecification', 'interactions');
+%! component = stats (a, 'Component', 'one');
+%! assert_equal (__anova_values__ (component), ...
+%!               __anova_values__ (stats (a)), 1e-10);
+%! summary_table = stats (a, 'summary');
+%! assert_equal (summary_table.Properties.RowNames, ...
+%!               {'Linear'; 'NonLinear'; 'Regression'; 'Error'; 'Total'});
+%! assert_equal (summary_table.SumOfSquares(1:3), ...
+%!               [20.25; 1 / 12; 61 / 3], 1e-10);
+%! assert_equal (summary_table.DF(1:3), [3; 2; 5]);
+%! assert_equal (summary_table.F(1:3), [48.6; 0.3; 29.28], 1e-10);
+
+%!test
+%! x = kron ((0:3)', ones (2, 1));
+%! y = [0; 0.2; 1; 1.2; 4; 4.2; 9; 9.2];
+%! summary_table = stats (anova (x, y, 'CategoricalFactors', []), 'summary');
+%! assert_equal (summary_table.Properties.RowNames, ...
+%!               {'Linear'; 'Regression'; 'Error'; 'LackOfFit'; ...
+%!                'PureError'; 'Total'});
+%! assert_equal (summary_table.SumOfSquares(3:5), [8.08; 8; 0.08], 1e-12);
+%! assert_equal (summary_table.DF(3:5), [6; 2; 4]);
+%! assert_equal (summary_table.F(4), 200, 1e-10);
+%! assert_equal (summary_table.pValue(4), 9.802960494567e-05, 1e-12);
+%! g = [ones(10, 1); 2 * ones(10, 1)];
+%! y = [(0:9)'; (1000:1009)'];
+%! summary_table = stats (anova (g, y), 'summary');
+%! assert_equal (summary_table.pValue(1) > 0, true);
+
+%!test
+%! [demo_code, demo_idx] = test ('anovan', 'grabdemo');
+%! assert_equal (numel (demo_idx) - 1, 13);
+%! for k = 1:numel (demo_idx) - 1
+%!   code = demo_code(demo_idx(k):demo_idx(k + 1) - 1);
+%!   code = strrep (code, "'display', 'on'", "'display', 'off'");
+%!   code = strrep (code, "anovan (y, g, 'weights', v.^-1)", ...
+%!                         "anovan (y, g, 'weights', v.^-1, 'display', 'off')");
+%!   code = regexprep (code, '^ *(figure|plot|xlabel) [^\n]*$', '', 'lineanchors');
+%!   eval (code);
+%!   switch (k)
+%!     case 1
+%!       a = anova (gender, score, 'FactorNames', {'gender'});
+%!     case 2
+%!       a = anova ({treatment(:), subject(:)}, score(:), ...
+%!                  'ModelSpecification', 'full', 'RandomFactors', 2, ...
+%!                  'SumOfSquaresType', 'two', ...
+%!                  'FactorNames', {'treatment', 'subject'});
+%!     case 3
+%!       a = anova (alloy, strength, 'FactorNames', {'alloy'});
+%!     case 4
+%!       a = anova ({seconds(:), subject(:)}, words(:), ...
+%!                  'ModelSpecification', 'full', 'RandomFactors', 2, ...
+%!                  'SumOfSquaresType', 'two', ...
+%!                  'FactorNames', {'seconds', 'subject'});
+%!     case 5
+%!       a = anova ({brands(:), popper(:)}, popcorn(:), ...
+%!                  'ModelSpecification', 'full', ...
+%!                  'FactorNames', {'brands', 'popper'});
+%!     case 6
+%!       a = anova ({gender, degree}, salary, 'ModelSpecification', 'full', ...
+%!                  'FactorNames', {'gender', 'degree'});
+%!     case 7
+%!       a = anova ({sugar, milk}, babble, 'ModelSpecification', 'full', ...
+%!                  'FactorNames', {'sugar', 'milk'});
+%!     case 8
+%!       a = anova ({drug(:), feedback(:), diet(:)}, BP(:), ...
+%!                  'ModelSpecification', 'full', ...
+%!                  'FactorNames', {'drug', 'feedback', 'diet'});
+%!     case 9
+%!       a = anova ({strain, treatment, block}, measurement / 10, ...
+%!                  'ModelSpecification', 'full', 'RandomFactors', 3, ...
+%!                  'SumOfSquaresType', 'two', ...
+%!                  'FactorNames', {'strain', 'treatment', 'block'});
+%!     case 10
+%!       a = anova ({species, temp}, pulse, 'CategoricalFactors', 1, ...
+%!                  'SumOfSquaresType', 'hierarchical', ...
+%!                  'FactorNames', {'species', 'temp'});
+%!     case 11
+%!       model = [1 0 0; 0 1 0; 0 0 1; 1 1 0];
+%!       a = anova ({treatment, exercise, age}, score, ...
+%!                  'ModelSpecification', model, 'CategoricalFactors', [1, 2], ...
+%!                  'SumOfSquaresType', 'hierarchical', ...
+%!                  'FactorNames', {'treatment', 'exercise', 'age'});
+%!     case 12
+%!       a = anova (g, dv, 'FactorNames', {'score'});
+%!     case 13
+%!       a = anova (g, y, 'Weights', v .^ -1);
+%!   endswitch
+%!   actual = stats (a);
+%!   actual_sources = actual.Properties.RowNames;
+%!   expected_sources = regexprep (ATAB(2:end, 1), "'$", "");
+%!   expected_sources = regexprep (expected_sources, "\\*", ":");
+%!   expected_sources = regexprep (expected_sources, "X([0-9]+)", "Factor$1");
+%!   if (strcmp (a.Stats.source, 'anova1'))
+%!     actual_sources{1} = expected_sources{1};
+%!   endif
+%!   assert_equal (actual_sources, expected_sources);
+%!   assert_equal (__anova_values__ (actual), ...
+%!                 __anova_values__ (ATAB), 1e-8);
+%!   if (! any (k == [1, 3, 12]))
+%!     assert_equal (a.Residuals, STATS.resid, 1e-8);
+%!     assert_equal (size (a.DesignMatrix), size (STATS.X));
+%!   endif
+%! endfor
 
 %!error <anova: RandomFactors must contain positive integer indices.> ...
 %! anova ([1;1;2;2], [1;2;3;4], 'RandomFactors', 0)
@@ -2207,3 +2759,19 @@ endclassdef
 %! y = [10; 12; 11; 14; 16; 15; 9; 8; 10];
 %! g = [1;1;1;2;2;2;3;3;3];
 %! predict (anova (g, y, 'SumOfSquaresType', 'two'), ones (2, 2));
+
+%!error <component type must be a character vector>
+%! a = anova ([1; 1; 2; 2], (1:4)');
+%! stats (a, 'Component', 1);
+
+%!error <component type must be 'one'>
+%! a = anova ([1; 1; 2; 2], (1:4)');
+%! stats (a, 'Component', 'typei');
+
+%!error <type must be 'component' or 'summary'>
+%! a = anova ([1; 1; 2; 2], (1:4)');
+%! stats (a, 'details');
+
+%!error <invalid input arguments>
+%! a = anova ([1; 1; 2; 2], (1:4)');
+%! stats (a, 'summary', 'one');

--- a/inst/Hypothesis_Testing/anova.m
+++ b/inst/Hypothesis_Testing/anova.m
@@ -56,35 +56,33 @@ classdef anova
     ##
     ## Factor data
     ##
-    ## Table whose variables are the factors used to fit the ANOVA model, with
-    ## one column per factor named after @code{FactorNames} and one row per
-    ## observation.  This property is read-only.
+    ## Table containing one variable for each factor used to fit the ANOVA
+    ## model.  This property is read-only.
     ##
     ## @end deftp
-    Factors         = [];
+    Factors
 
     ## -*- texinfo -*-
     ## @deftp {anova} {property} Formula
     ##
     ## Model formula
     ##
-    ## Character vector describing the fitted ANOVA model formula.  (MATLAB
-    ## returns a formula object; Octave returns the equivalent character
-    ## vector.)  This property is read-only.
+    ## Read-only structural formula value with response, predictor, term,
+    ## nesting, and linear-predictor fields matching MATLAB's formula object.
     ##
     ## @end deftp
-    Formula         = '';
+    Formula         = struct ();
 
     ## -*- texinfo -*-
     ## @deftp {anova} {property} FactorNames
     ##
     ## Factor names
     ##
-    ## Cell array of character vectors used as factor names in the fitted
-    ## ANOVA table.  This property is read-only.
+    ## String row vector containing the factor names used by the fitted ANOVA
+    ## model.  This property is read-only.
     ##
     ## @end deftp
-    FactorNames     = {};
+    FactorNames     = [];
 
     ## -*- texinfo -*-
     ## @deftp {anova} {property} ExpandedFactorNames
@@ -103,7 +101,7 @@ classdef anova
     ##
     ## Sum-of-squares type
     ##
-    ## Character vector selecting @qcode{'one'}, @qcode{'two'},
+    ## String scalar selecting @qcode{"one"}, @qcode{"two"},
     ## @qcode{'three'}, or @qcode{'hierarchical'} sums of squares.  This
     ## property is read-only.
     ##
@@ -126,8 +124,8 @@ classdef anova
     ##
     ## Categorical factors
     ##
-    ## Character vector @qcode{'all'} or positive integer indices of factors
-    ## treated as categorical.  This property is read-only.
+    ## Positive integer indices of factors treated as categorical.  This
+    ## property is read-only.
     ##
     ## @end deftp
     CategoricalFactors = 'all';
@@ -161,8 +159,8 @@ classdef anova
     ##
     ## Model coefficient estimates
     ##
-    ## Numeric coefficient table returned by the fitted @code{anovan} backend,
-    ## or derived from a @code{LinearModel} object.  This property is read-only.
+    ## Numeric vector of fitted coefficient estimates.  This property is
+    ## read-only.
     ##
     ## @end deftp
     Coefficients   = [];
@@ -197,6 +195,7 @@ classdef anova
     ## Backend aliases and Octave-specific extensions retained for internal
     ## use and power users; kept off the documented MATLAB property surface.
     GROUP                                   ## raw factor data (fit workhorse)
+    Response     = [];
     ModelType    = 'linear';
     ModelSpecification = 'linear';
     SSType       = 3;
@@ -223,13 +222,18 @@ classdef anova
   endproperties
 
   properties (Access = private)
-    fitted_       = false;
-    dirty_        = true;
-    nFactors_     = 0;
-    backend_      = '';                     ## 'anova1' | 'anova2' | 'anovan'
-    reps_         = [];                     ## anova2 replicate count
-    sourceModel_  = [];                     ## LinearModel object, when supplied
-    rawResiduals_ = [];                     ## raw residual vector for internals
+    fitted_     = false;
+    dirty_      = true;
+    nFactors_   = 0;
+    backend_    = '';                       ## 'anova1' | 'anova2' | 'anovan'
+    reps_       = [];                       ## replicate count for anova2 backend
+    sourceModel_ = [];                       ## LinearModel object, when supplied
+    continuousSpecified_ = false;
+    coefficientStats_ = [];
+    rawResiduals_ = [];
+    nesting_ = [];
+    formulaText_ = '';
+    formulaTerms_ = [];
   endproperties
 
   methods (Access = public)
@@ -237,6 +241,10 @@ classdef anova
     ## -*- texinfo -*-
     ## @deftypefn  {anova} {@var{obj} =} anova (@var{Y})
     ## @deftypefnx {anova} {@var{obj} =} anova (@var{factors}, @var{Y})
+    ## @deftypefnx {anova} {@var{obj} =} anova (@var{tbl}, @var{Y})
+    ## @deftypefnx {anova} {@var{obj} =} anova (@var{tbl},
+    ## @var{responseVarName})
+    ## @deftypefnx {anova} {@var{obj} =} anova (@var{tbl}, @var{formula})
     ## @deftypefnx {anova} {@var{obj} =} anova (@dots{}, @var{name}, @var{value})
     ## @deftypefnx {anova} {@var{obj} =} anova (@var{mdl})
     ##
@@ -248,6 +256,11 @@ classdef anova
     ## grouping vectors.  If @var{factors} is omitted and @var{Y} is a matrix,
     ## columns of @var{Y} are treated as groups following @code{anova1} matrix
     ## syntax.
+    ##
+    ## @var{tbl} is a table whose variables contain factors.  The response may
+    ## be supplied separately, selected by variable name, or specified with a
+    ## Wilkinson formula.  @qcode{'FactorNames'} can select a subset of table
+    ## variables when a formula is not supplied.
     ##
     ## Supported name-value arguments include @qcode{'ModelSpecification'},
     ## @qcode{'SumOfSquaresType'}, @qcode{'FactorNames'},
@@ -269,6 +282,10 @@ classdef anova
         Y = [];
       endif
 
+      table_factors = [];
+      formula_input = "";
+      response_locked = false;
+
       if (isa (factors, 'LinearModel'))
         lm_args = varargin;
         if (! isempty (Y))
@@ -278,7 +295,29 @@ classdef anova
         return;
       endif
 
-      if (nargin < 2)
+      if (isa (factors, "table"))
+        if (nargin < 2)
+          error (strcat ("anova: table input requires response data or", ...
+                         " a response name."));
+        endif
+        if (mod (numel (varargin), 2) != 0)
+          error ("anova: name-value pairs must come in pairs.");
+        endif
+        response_locked = obj.isName_ (Y);
+        [factors, Y, table_factors, table_names, response_name, ...
+         formula_input, formula_model, formula_nesting] = ...
+          obj.parseTableInput_ (factors, Y, varargin{:});
+        obj.VarNames = table_names;
+        obj.FactorNames = string (table_names);
+        obj.ResponseName = response_name;
+        if (! isempty (formula_input))
+          obj.formulaText_ = formula_input;
+          obj.formulaTerms_ = formula_model;
+          obj.ModelSpecification = formula_input;
+          obj.ModelType = formula_model;
+          obj.nesting_ = formula_nesting;
+        endif
+      elseif (nargin < 2)
         Y = factors;
         factors = [];
       elseif (isempty (Y) && isnumeric (factors))
@@ -297,8 +336,9 @@ classdef anova
         error ("anova: name-value pairs must come in pairs.");
       endif
 
-      obj.Y     = Y;
-      obj.GROUP = factors;
+      obj.Response = Y;
+      obj.Y        = Y(:);
+      obj.GROUP    = factors;
 
       ## Parse name-value pairs (mirrors anovan.m's loop style)
       for idx = 1:2:numel (varargin)
@@ -309,11 +349,15 @@ classdef anova
         endif
         switch (lower (name))
           case {'model', 'modelspecification'}
-            obj = obj.setModelSpecification_ (value);
+            if (isempty (formula_input))
+              obj = obj.setModelSpecification_ (value);
+            endif
           case {'sstype', 'sumofsquarestype'}
             obj = obj.setSumOfSquaresType_ (value);
           case {'varnames', 'factornames'}
-            obj = obj.setFactorNames_ (value);
+            if (isempty (formula_input))
+              obj = obj.setFactorNames_ (value);
+            endif
           case 'contrasts'
             obj.Contrasts = value;
           case 'alpha'
@@ -322,6 +366,7 @@ classdef anova
             obj.CategoricalFactors = value;
           case {'continuous'}
             obj.Continuous = value;
+            obj.continuousSpecified_ = true;
           case {'random', 'randomfactors'}
             obj.RandomFactors = value;
             obj.Random = value;
@@ -330,7 +375,9 @@ classdef anova
           case {'display', 'displayopt'}
             obj.Display = value;
           case 'responsename'
-            obj.ResponseName = value;
+            if (! response_locked)
+              obj.ResponseName = value;
+            endif
           case 'reps'
             obj.reps_ = value;
           otherwise
@@ -338,14 +385,31 @@ classdef anova
         endswitch
       endfor
 
+      [obj.Response, obj.GROUP, obj.Weights, table_factors] = ...
+        obj.removeMissing_ (obj.Response, obj.GROUP, obj.Weights, ...
+                            table_factors);
+      obj.GROUP = obj.normalizeGroups_ (obj.GROUP);
+      obj.Y = obj.Response(:);
       obj.nFactors_ = obj.countFactors_ ();
       obj.NumFactors = obj.nFactors_;
-      obj.NumObservations = numel (obj.Y);
-      obj = obj.syncCategoricalFactors_ ();
-      obj = obj.setFormula_ ();
+      obj.NumObservations = numel (obj.Response);
+      if (isnumeric (obj.ModelType) && isscalar (obj.ModelType))
+        obj.ModelType = min (obj.ModelType, obj.nFactors_);
+      endif
+      if (isempty (formula_input))
+        obj = obj.setFormula_ ();
+      endif
+      obj.FactorNames = string (obj.VarNames);
+      obj.SumOfSquaresType = string (obj.SumOfSquaresType);
+      obj = obj.updateFormula_ ();
+      obj = obj.syncFactorSelectors_ ();
       obj.validateSpec_ ();
       obj.validateData_ ();
-      obj.Factors = obj.buildFactorsTable_ ();
+      if (isempty (table_factors))
+        obj.Factors = obj.factorTable_ ();
+      else
+        obj.Factors = table_factors;
+      endif
       obj = obj.selectBackend_ ();
       obj.dirty_ = true;
       ## Fit eagerly at construction so result properties are populated on the
@@ -419,8 +483,8 @@ classdef anova
       constrained = 'constrained';
       fprintf ("\n  %d-way anova, %s (Type %s) sums of squares.\n\n", ...
                obj.NumFactors, constrained, obj.sstypeLabel_ ());
-      if (! isempty (obj.Formula))
-        fprintf ("  %s\n\n", obj.Formula);
+      if (! isempty (obj.formulaText_))
+        fprintf ("  %s\n\n", obj.formulaText_);
       endif
       obj.printAtab_ (obj.AnovaTable);
       fprintf ("\n  Properties, Methods\n\n");
@@ -495,94 +559,194 @@ classdef anova
     ## @end deftypefn
     function means = groupmeans (obj, factors, varargin)
       if (nargin < 2 || isempty (factors))
-        factors = 1:obj.NumFactors;
+        if (obj.NumFactors != 1)
+          error (strcat ("anova.groupmeans: factors must be specified for", ...
+                         " a multi-factor ANOVA."));
+        endif
+        factors = obj.VarNames;
       endif
       alpha = obj.parseAlpha_ (varargin{:});
       obj.ensureFit_ ();
-      [G, names] = obj.selectedFactorMatrix_ (factors);
+      idx = obj.factorIndices_ (factors);
+      names = obj.VarNames(idx);
       y = obj.Y(:);
-      if (isempty (G))
+      if (isempty (idx))
         error ("anova.groupmeans: factors are required for group means.");
       endif
-      [levels, ~, gid] = unique (G, 'rows');
-      n = accumarray (gid, 1);
-      mu = accumarray (gid, y, [], @mean);
+      [gid, levels] = findgroups (obj.Factors(:, names));
+      valid = isfinite (y) & isfinite (gid) & gid > 0;
+      used = unique (gid(valid), "stable");
+      [~, compact] = ismember (gid(valid), used);
+      levels = levels(used, :);
+      n = accumarray (compact, 1);
+      mu = accumarray (compact, y(valid), [], @mean);
       se = sqrt (obj.MSE ./ n);
       crit = tinv (1 - alpha / 2, max (obj.DFE, 1));
-      lo = mu - crit * se;
-      hi = mu + crit * se;
-      values = num2cell (levels, 1);
-      values = [values, {mu, se, lo, hi}];
-      vnames = [names, {'Mean', 'SE', 'MeanLower', 'MeanUpper'}];
-      means = table (values{:}, 'VariableNames', vnames);
+      lower = mu - crit * se;
+      upper = mu + crit * se;
+      intervals = table (mu, se, lower, upper, "VariableNames", ...
+                         {"Mean", "SE", "MeanLower", "MeanUpper"});
+      means = [levels, intervals];
     endfunction
 
     ## -*- texinfo -*-
     ## @deftypefn  {anova} {} boxchart (@var{obj})
     ## @deftypefnx {anova} {@var{h} =} boxchart (@var{obj}, @dots{})
     ##
-    ## Plot a one-way box chart of response values by factor.
+    ## Plot response values grouped by up to two categorical factors.
     ##
-    ## This method uses @code{boxplot} as the graphics backend in Octave.
+    ## This method uses @code{boxplot} as the graphics backend in Octave and
+    ## returns the native box graphics handles.  A target axes may be supplied
+    ## as the first optional argument.
     ##
     ## @end deftypefn
     function h = boxchart (obj, varargin)
       obj.ensureFit_ ();
-      [G, ~] = obj.selectedFactorMatrix_ (1);
-      if (isempty (G))
-        error ("anova.boxchart: a one-way factor is required.");
+      [target, varargin] = obj.extractAxes_ (varargin);
+      factors = {};
+      if (! isempty (varargin))
+        candidate = varargin{1};
+        if (isstring (candidate))
+          candidate = cellstr (candidate(:))';
+        elseif (ischar (candidate))
+          candidate = {candidate};
+        endif
+        if (iscellstr (candidate) ...
+            && all (ismember (candidate, obj.VarNames)))
+          factors = candidate;
+          varargin(1) = [];
+        endif
       endif
-      h = boxplot (obj.Y(:), G(:, 1), varargin{:});
+      if (isempty (factors))
+        if (obj.NumFactors != 1)
+          error (strcat ("anova.boxchart: factors must be specified for", ...
+                         " a multi-factor ANOVA."));
+        endif
+        factors = obj.VarNames;
+      endif
+      idx = obj.factorIndices_ (factors);
+      if (numel (idx) > 2)
+        error ("anova.boxchart: at most two factors can be plotted.");
+      endif
+      if (! all (ismember (idx, obj.CategoricalFactors)))
+        error ("anova.boxchart: factors must be categorical.");
+      endif
+      grouping = cell (1, numel (idx));
+      for k = 1:numel (idx)
+        grouping{k} = obj.Factors{:, obj.VarNames{idx(k)}};
+      endfor
+      if (numel (grouping) == 1)
+        grouping = grouping{1};
+      endif
+      if (! isempty (target))
+        axes (target);
+      endif
+      [~, handles] = boxplot (obj.Y(:), grouping, "notch", "on", ...
+                              varargin{:});
+      h = handles.box;
     endfunction
 
     ## -*- texinfo -*-
     ## @deftypefn  {anova} {} plotComparisons (@var{obj})
     ## @deftypefnx {anova} {@var{h} =} plotComparisons (@var{obj}, @dots{})
     ##
-    ## Plot multiple-comparison intervals for group means.
+    ## Plot multiple-comparison intervals for model-adjusted group means.
     ##
-    ## The method delegates interval computation to @code{multcompare}.
+    ## Clicking a group highlights it and distinguishes groups whose adjusted
+    ## comparison is significant at the requested alpha level.  A target axes
+    ## may be supplied as the first optional argument.
     ##
     ## @end deftypefn
     function h = plotComparisons (obj, varargin)
       obj.ensureFit_ ();
-      [~, ~, h] = multcompare (obj, 'display', 'on', varargin{:});
+      [target, varargin] = obj.extractAxes_ (varargin);
+      [stats_, args, sidak] = obj.comparisonArguments_ (varargin{:});
+      args = obj.replaceOption_ (args, "display", "off");
+      alpha = obj.optionValue_ (args, "alpha", obj.Alpha);
+      [comparisons, means, ~, names] = multcompare (stats_, args{:});
+      if (! isempty (sidak) && ! isempty (comparisons))
+        per_comparison = 1 - (1 - sidak) ^ (1 / rows (comparisons));
+        critical = tinv (1 - per_comparison / 2, comparisons(1, 8));
+        half_width = means(:, 2) * critical / sqrt (2);
+        means(:, 3:4) = [means(:, 1) - half_width, ...
+                         means(:, 1) + half_width];
+        comparisons(:, 6) = 1 - (1 - comparisons(:, 6)) ...
+                                .^ rows (comparisons);
+      endif
+      if (isempty (target))
+        target = gca ();
+      endif
+      h = ancestor (target, "figure");
+      cla (target);
+      hold (target, "on");
+      count = rows (means);
+      intervals = zeros (count, 1);
+      markers = zeros (count, 1);
+      for group = 1:count
+        intervals(group) = line (target, means(group, 3:4), ...
+                                 [group, group], "color", [0.35, 0.35, 0.35], ...
+                                 "linewidth", 1.5);
+        markers(group) = line (target, means(group, 1), group, ...
+                               "linestyle", "none", "marker", "o", ...
+                               "markerfacecolor", [0.00, 0.45, 0.74], ...
+                               "markeredgecolor", [0.00, 0.45, 0.74]);
+      endfor
+      hold (target, "off");
+      set (target, "ydir", "reverse", "ytick", 1:count, ...
+                   "yticklabel", names);
+      ylim (target, [0.5, count + 0.5]);
+      xlabel (target, sprintf ("Group mean with %g%% comparison interval", ...
+                               100 * (1 - alpha)));
+      title (target, "Multiple comparisons");
+      for group = 1:count
+        set (markers(group), "buttondownfcn", ...
+             @(~, ~) obj.highlightComparison_ (group, markers, intervals, ...
+                                                comparisons, alpha));
+      endfor
+      if (count > 0)
+        obj.highlightComparison_ (1, markers, intervals, comparisons, alpha);
+      endif
     endfunction
 
     ## -*- texinfo -*-
     ## @deftypefn  {anova} {@var{v} =} varianceComponent (@var{obj})
     ## @deftypefnx {anova} {@var{v} =} varianceComponent (@var{obj}, @dots{})
     ##
-    ## Return variance component estimates for the error term.
-    ##
-    ## Random-factor variance component estimates are not yet implemented.
+    ## Return variance component estimates for random model terms and error.
     ##
     ## @end deftypefn
     function v = varianceComponent (obj, varargin)
       alpha = obj.parseAlpha_ (varargin{:});
       obj.ensureFit_ ();
-      if (! isempty (obj.RandomFactors))
-        error ("anova.varianceComponent: random factors are not implemented.");
-      endif
-      lo = obj.DFE * obj.MSE / chi2inv (1 - alpha / 2, obj.DFE);
-      hi = obj.DFE * obj.MSE / chi2inv (alpha / 2, obj.DFE);
-      v = table ({'Error'}, obj.MSE, lo, hi, 'VariableNames', ...
-                 {'Source', 'VarianceComponent', ...
-                  'VarianceComponentLower', 'VarianceComponentUpper'});
+      [coefficients, mean_squares, dfs, names] = ...
+        obj.varianceSystem_ (obj.Stats, obj.AnovaTable, obj.SSType);
+      estimates = coefficients \ mean_squares;
+      lower_ms = dfs .* mean_squares ./ chi2inv (1 - alpha / 2, dfs);
+      upper_ms = dfs .* mean_squares ./ chi2inv (alpha / 2, dfs);
+      inverse = pinv (coefficients);
+      lower = sum (max (inverse, 0) .* lower_ms' ...
+                   + min (inverse, 0) .* upper_ms', 2);
+      upper = sum (max (inverse, 0) .* upper_ms' ...
+                   + min (inverse, 0) .* lower_ms', 2);
+      v = table (estimates, lower, upper, "VariableNames", ...
+                 {"VarianceComponent", "VarianceComponentLower", ...
+                  "VarianceComponentUpper"}, "RowNames", names);
     endfunction
 
     ## -*- texinfo -*-
-    ## @deftypefn  {anova} {@var{C} =} multcompare (@var{obj})
-    ## @deftypefnx {anova} {[@var{C}, @var{M}, @var{H}, @var{GNAMES}] =} multcompare (@var{obj}, @dots{})
+    ## @deftypefn  {anova} {@var{m} =} multcompare (@var{obj})
+    ## @deftypefnx {anova} {@var{m} =} multcompare (@var{obj}, @var{factors})
+    ## @deftypefnx {anova} {@var{m} =} multcompare (@dots{}, @var{name},
+    ## @var{value})
     ##
     ## Perform post-hoc multiple comparisons for a fitted ANOVA object.
     ##
-    ## The method fits the object if needed and delegates to the package
-    ## function @code{multcompare} using the backend @code{Stats} structure.
-    ## Additional arguments are passed through unchanged.
+    ## The returned table contains the compared groups, estimated mean
+    ## difference, confidence limits, and p-value.  The default critical value
+    ## type is @qcode{"tukey-kramer"}.
     ##
     ## @end deftypefn
-    function varargout = multcompare (obj, varargin)
+    function m = multcompare (obj, varargin)
       obj.ensureFit_ ();
       if (strcmp (obj.backend_, 'linearmodel'))
         error ("anova.multcompare: LinearModel-backed ANOVA is not supported.");
@@ -590,8 +754,26 @@ classdef anova
       if (isempty (fieldnames (obj.Stats)))
         error ("anova.multcompare: model has no stats to compare.");
       endif
-      varargout = cell (1, max (nargout, 1));
-      [varargout{:}] = multcompare (obj.Stats, varargin{:});
+      [stats_, args, sidak, dims] = obj.comparisonArguments_ (varargin{:});
+      gid = findgroups (obj.Factors(:, obj.VarNames(dims)));
+      if (numel (unique (gid(isfinite (gid) & gid > 0))) < 2)
+        m = obj.comparisonTable_ (zeros (0, 6), cell (0, 1), dims);
+        return;
+      endif
+      [C, ~, ~, group_names] = multcompare (stats_, args{:});
+      if (! isempty (sidak))
+        per_comparison = 1 - (1 - sidak) ^ (1 / rows (C));
+        old_critical = tinv (1 - sidak / 2, C(:, 8));
+        standard_error = (C(:, 5) - C(:, 3)) ./ (2 * old_critical);
+        critical = tinv (1 - per_comparison / 2, C(:, 8));
+        C(:, 3) = C(:, 4) - critical .* standard_error;
+        C(:, 5) = C(:, 4) + critical .* standard_error;
+        C(:, 6) = 1 - (1 - C(:, 6)) .^ rows (C);
+      endif
+      if (strcmp (stats_.source, "anovan"))
+        group_names = obj.comparisonGroups_ (stats_, dims);
+      endif
+      m = obj.comparisonTable_ (C, group_names, dims);
     endfunction
 
   endmethods
@@ -673,7 +855,11 @@ classdef anova
       if (isempty (obj.Coefficients))
         error ("anova.predict: coefficients are unavailable for this backend.");
       endif
-      beta = obj.Coefficients(:, 1);
+      if (! isempty (obj.coefficientStats_))
+        beta = obj.coefficientStats_(:, 1);
+      else
+        beta = obj.Coefficients;
+      endif
       if (! isnumeric (Xnew) || columns (Xnew) != numel (beta))
         error (strcat ("anova.predict: Xnew must be a numeric design", ...
                        " matrix with %d columns."), numel (beta));
@@ -710,6 +896,304 @@ classdef anova
       tf = ischar (value) || (isstring (value) && isscalar (value));
     endfunction
 
+    function [target, args] = extractAxes_ (obj, args)
+      target = [];
+      if (! isempty (args) && isscalar (args{1}) ...
+          && ishghandle (args{1}) ...
+          && strcmp (get (args{1}, "type"), "axes"))
+        target = args{1};
+        args(1) = [];
+      endif
+    endfunction
+
+    function highlightComparison_ (obj, selected, markers, intervals, ...
+                                   comparisons, alpha)
+      neutral = [0.45, 0.45, 0.45];
+      different = [0.85, 0.20, 0.16];
+      chosen = [0.00, 0.45, 0.74];
+      for group = 1:numel (markers)
+        color = neutral;
+        if (group == selected)
+          color = chosen;
+        else
+          row = find ((comparisons(:, 1) == selected ...
+                       & comparisons(:, 2) == group) ...
+                      | (comparisons(:, 2) == selected ...
+                         & comparisons(:, 1) == group), 1);
+          if (! isempty (row) && comparisons(row, 6) < alpha)
+            color = different;
+          endif
+        endif
+        set (markers(group), "markerfacecolor", color, ...
+             "markeredgecolor", color);
+        set (intervals(group), "color", color);
+      endfor
+    endfunction
+
+    function [groups, response, factor_table, factor_names, response_name, ...
+              formula, model, nesting] = parseTableInput_ (obj, tbl, ...
+                                                            response_arg, ...
+                                                            varargin)
+      variable_names = tbl.Properties.VariableNames;
+      formula = "";
+      model = [];
+      nesting = [];
+      if (isnumeric (response_arg))
+        response = response_arg;
+        response_name = "Y";
+        factor_names = variable_names;
+      elseif (obj.isName_ (response_arg))
+        value = char (response_arg);
+        if (! isempty (strfind (value, "~")))
+          formula = value;
+          schema = parseWilkinsonFormula (formula, "matrix");
+          if (! isscalar (schema.ResponseIdx))
+            error ("anova: formula must specify one response variable.");
+          endif
+          response_name = schema.VariableNames{schema.ResponseIdx};
+          [factor_names, model] = obj.schemaModel_ (schema);
+          ordered = variable_names(ismember (variable_names, factor_names));
+          [~, order] = ismember (ordered, factor_names);
+          factor_names = ordered;
+          model = model(:, order);
+          [model, nesting] = obj.nestedSpecification_ (formula, ...
+                                                       factor_names, model);
+        else
+          response_name = value;
+          factor_names = variable_names(! strcmp (variable_names, value));
+        endif
+        if (! any (strcmp (variable_names, response_name)))
+          error ("anova: response variable '%s' is not in the table.", ...
+                 response_name);
+        endif
+        response = tbl{:, response_name};
+      else
+        error (strcat ("anova: table response must be numeric, a response", ...
+                       " variable name, or a formula."));
+      endif
+
+      if (! isempty (formula))
+        missing = ! ismember (factor_names, variable_names);
+        if (any (missing))
+          error ("anova: formula variable '%s' is not in the table.", ...
+                 factor_names{find (missing, 1)});
+        endif
+      else
+        selected = obj.optionValue_ (varargin, "factornames", []);
+        if (! isempty (selected))
+          if (isstring (selected))
+            selected = cellstr (selected(:))';
+          elseif (ischar (selected))
+            selected = {selected};
+          endif
+          if (! iscellstr (selected) ...
+              || ! all (ismember (selected, factor_names)))
+            error (strcat ("anova: FactorNames must identify factor", ...
+                           " variables in the table."));
+          endif
+          factor_names = selected;
+        endif
+      endif
+      if (! isnumeric (response) || isempty (response) || ! isvector (response))
+        error (strcat ("anova: table response data must be a non-empty", ...
+                       " numeric vector."));
+      endif
+      if (numel (response) != height (tbl))
+        error (strcat ("anova: table and response must contain the same", ...
+                       " number of rows."));
+      endif
+
+      factor_table = tbl(:, factor_names);
+      groups = cell (1, numel (factor_names));
+      for k = 1:numel (factor_names)
+        groups{k} = tbl{:, factor_names{k}};
+        if (ischar (groups{k}) && rows (groups{k}) > 1)
+          groups{k} = cellstr (groups{k});
+        endif
+      endfor
+      if (numel (groups) == 1)
+        groups = groups{1};
+      endif
+    endfunction
+
+    function [factor_names, model] = schemaModel_ (obj, schema)
+      predictor_idx = setdiff (1:numel (schema.VariableNames), ...
+                               schema.ResponseIdx, "stable");
+      used = any (schema.Terms(:, predictor_idx) != 0, 1);
+      predictor_idx = predictor_idx(used);
+      factor_names = {};
+      exponents = zeros (1, numel (predictor_idx));
+      factor_idx = zeros (1, numel (predictor_idx));
+      for k = 1:numel (predictor_idx)
+        name = schema.VariableNames{predictor_idx(k)};
+        token = regexp (name, '^(.*)\^(\d+)$', 'tokens', 'once');
+        if (isempty (token))
+          base = name;
+          exponents(k) = 1;
+        else
+          base = token{1};
+          exponents(k) = str2double (token{2});
+        endif
+        idx = find (strcmp (factor_names, base), 1);
+        if (isempty (idx))
+          factor_names{end + 1} = base;
+          idx = numel (factor_names);
+        endif
+        factor_idx(k) = idx;
+      endfor
+      model = zeros (rows (schema.Terms), numel (factor_names));
+      for k = 1:numel (predictor_idx)
+        rows_ = schema.Terms(:, predictor_idx(k)) != 0;
+        model(rows_, factor_idx(k)) = exponents(k);
+      endfor
+      model(! any (model, 2), :) = [];
+      model = unique (model, "rows", "stable");
+    endfunction
+
+    function [model, nesting] = nestedSpecification_ (obj, formula, ...
+                                                       factor_names, model)
+      nesting = false (numel (factor_names));
+      definitions = regexp (formula, ...
+                            '([A-Za-z]\w*)\s*\(([^()]*)\)', ...
+                            'tokens');
+      for k = 1:numel (definitions)
+        child_name = definitions{k}{1};
+        parent_names = strtrim (strsplit (definitions{k}{2}, ','));
+        child = find (strcmp (factor_names, child_name), 1);
+        [found, parents] = ismember (parent_names, factor_names);
+        if (isempty (child) || ! all (found))
+          error ("anova: nested formula contains an unknown factor.");
+        endif
+        nesting(child, parents) = true;
+        members = [child, parents];
+        rows_ = all (model(:, members) > 0, 2) ...
+                & sum (model > 0, 2) == numel (members);
+        replacement = zeros (1, columns (model));
+        replacement(child) = 1;
+        model(rows_, :) = repmat (replacement, sum (rows_), 1);
+      endfor
+      model = unique (model, "rows", "stable");
+    endfunction
+
+    function value = optionValue_ (obj, args, option, default)
+      value = default;
+      for k = 1:2:numel (args)
+        if (obj.isName_ (args{k}) && strcmpi (char (args{k}), option))
+          value = args{k + 1};
+        endif
+      endfor
+    endfunction
+
+    function factors = factorTable_ (obj)
+      if (obj.nFactors_ == 0)
+        factors = table ();
+        return;
+      endif
+      if (isempty (obj.GROUP) && ! isvector (obj.Response))
+        if (isempty (obj.reps_))
+          [n, groups] = size (obj.Response);
+          group_values = reshape (repmat (1:groups, n, 1), [], 1);
+          columns_ = {group_values};
+        else
+          [~, columns_] = obj.anova2Data_ ();
+        endif
+      elseif (iscell (obj.GROUP) ...
+              && size (obj.GROUP, 1) == 1 ...
+              && numel (obj.GROUP) == obj.nFactors_)
+        columns_ = cellfun (@(x) x(:), obj.GROUP, "UniformOutput", false);
+      elseif (obj.nFactors_ == 1)
+        columns_ = {obj.GROUP(:)};
+      else
+        columns_ = cell (1, obj.nFactors_);
+        for k = 1:obj.nFactors_
+          columns_{k} = obj.GROUP(:, k);
+        endfor
+      endif
+      factors = table (columns_{:}, "VariableNames", obj.VarNames);
+    endfunction
+
+    function [response, groups, weights, factor_table] = removeMissing_ (...
+                                      obj, response, groups, weights, ...
+                                      factor_table)
+      if (! isvector (response))
+        if (! isempty (obj.reps_))
+          return;
+        elseif (isempty (groups) && any (! isfinite (response(:))))
+          [n, levels] = size (response);
+          groups = reshape (repmat (1:levels, n, 1), [], 1);
+          response = response(:);
+        else
+          return;
+        endif
+      endif
+      valid = isfinite (response(:));
+      columns_ = obj.groupColumns_ (groups);
+      for k = 1:numel (columns_)
+        group_id = grp2idx (columns_{k});
+        if (numel (group_id) != numel (valid))
+          return;
+        endif
+        valid &= isfinite (group_id);
+      endfor
+      if (all (valid))
+        return;
+      endif
+      if (! any (valid))
+        error (strcat ("anova: no complete observations remain after", ...
+                       " removing missing data."));
+      endif
+      response = response(valid);
+      if (iscell (groups) && size (groups, 1) == 1 ...
+          && numel (groups) == numel (columns_))
+        for k = 1:numel (groups)
+          value = groups{k};
+          if (ischar (value) && rows (value) > 1)
+            groups{k} = value(valid, :);
+          else
+            groups{k} = value(valid);
+          endif
+        endfor
+      elseif (! isempty (groups))
+        groups = groups(valid, :);
+      endif
+      if (! isempty (weights) && numel (weights) != numel (valid))
+        return;
+      elseif (! isempty (weights))
+        weights = weights(valid);
+      endif
+      if (isa (factor_table, "table") && width (factor_table) > 0)
+        factor_table = factor_table(valid, :);
+      endif
+    endfunction
+
+    function columns_ = groupColumns_ (obj, groups)
+      if (isempty (groups))
+        columns_ = {};
+      elseif (iscell (groups) && size (groups, 1) == 1 ...
+              && all (cellfun (@(x) isvector (x) || ischar (x), groups)))
+        columns_ = groups;
+      elseif (isvector (groups) || ischar (groups))
+        columns_ = {groups};
+      else
+        columns_ = cell (1, columns (groups));
+        for k = 1:columns (groups)
+          columns_{k} = groups(:, k);
+        endfor
+      endif
+    endfunction
+
+    function groups = normalizeGroups_ (obj, groups)
+      if (ischar (groups) && rows (groups) > 1)
+        groups = cellstr (groups);
+      elseif (iscell (groups) && size (groups, 1) == 1)
+        for k = 1:numel (groups)
+          if (ischar (groups{k}) && rows (groups{k}) > 1)
+            groups{k} = cellstr (groups{k});
+          endif
+        endfor
+      endif
+    endfunction
+
     function obj = setModelSpecification_ (obj, value)
       if (isstring (value) && isscalar (value))
         value = char (value);
@@ -729,7 +1213,7 @@ classdef anova
           error (strcat ("anova: SumOfSquaresType must be 'one',", ...
                          " 'two', 'three', or 'hierarchical'."));
         endif
-        obj.SumOfSquaresType = names{value};
+        obj.SumOfSquaresType = string (names{value});
         obj.SSType = value;
         return;
       endif
@@ -740,14 +1224,17 @@ classdef anova
         error ("anova: SumOfSquaresType must be a character vector.");
       endif
       switch (lower (value))
-        case {'one', 'typei', 'i'}
-          obj.SumOfSquaresType = 'one';
+        case {"one", "typei", "i"}
+          obj.SumOfSquaresType = string ("one");
           obj.SSType = 1;
-        case {'two', 'typeii', 'ii', 'hierarchical'}
-          obj.SumOfSquaresType = lower (value);
+        case {"two", "typeii", "ii"}
+          obj.SumOfSquaresType = string ("two");
           obj.SSType = 2;
-        case {'three', 'typeiii', 'iii'}
-          obj.SumOfSquaresType = 'three';
+        case "hierarchical"
+          obj.SumOfSquaresType = string ("hierarchical");
+          obj.SSType = "h";
+        case {"three", "typeiii", "iii"}
+          obj.SumOfSquaresType = string ("three");
           obj.SSType = 3;
         otherwise
           error (strcat ("anova: SumOfSquaresType must be 'one',", ...
@@ -783,63 +1270,245 @@ classdef anova
       elseif (ischar (value))
         value = {value};
       endif
-      obj.FactorNames = value;
       obj.VarNames = value;
+      obj.FactorNames = string (value);
     endfunction
 
-    function obj = syncCategoricalFactors_ (obj)
-      if (obj.isName_ (obj.CategoricalFactors) ...
-          && strcmpi (char (obj.CategoricalFactors), 'all'))
-        obj.Continuous = [];
+    function obj = syncFactorSelectors_ (obj)
+      if (obj.continuousSpecified_)
+        continuous = obj.normalizeFactorSelector_ (obj.Continuous, ...
+                                                    "CategoricalFactors", ...
+                                                    false);
+        obj.Continuous = continuous;
+        obj.CategoricalFactors = setdiff (1:obj.nFactors_, continuous);
+      else
+        obj.CategoricalFactors = obj.normalizeFactorSelector_ (...
+                                   obj.CategoricalFactors, ...
+                                   "CategoricalFactors", true);
+        obj.Continuous = setdiff (1:obj.nFactors_, ...
+                                  obj.CategoricalFactors);
+      endif
+      obj.RandomFactors = obj.normalizeFactorSelector_ (obj.RandomFactors, ...
+                                                        "RandomFactors", ...
+                                                        true);
+      obj.Random = obj.RandomFactors;
+    endfunction
+
+    function idx = normalizeFactorSelector_ (obj, value, option, allow_all)
+      if (isempty (value))
+        idx = [];
         return;
       endif
-      if (! isnumeric (obj.CategoricalFactors))
-        error (strcat ("anova: CategoricalFactors must be 'all' or a", ...
-                       " numeric index vector."));
+      if (obj.isName_ (value) && strcmpi (char (value), "all"))
+        if (! allow_all)
+          error ("anova: %s must identify valid factors.", option);
+        endif
+        idx = 1:obj.nFactors_;
+        return;
       endif
-      cats = obj.CategoricalFactors(:)';
-      if (! isempty (cats) ...
-          && (! isvector (cats) || any (cats != fix (cats)) ...
-              || any (cats < 1) || any (cats > obj.nFactors_)))
-        error ("anova: CategoricalFactors must contain valid factor indices.");
+      if (islogical (value))
+        if (! isvector (value) || numel (value) != obj.nFactors_)
+          error ("anova: %s logical input must have one value per factor.", ...
+                 option);
+        endif
+        idx = find (value(:))';
+        return;
       endif
-      obj.Continuous = setdiff (1:obj.nFactors_, cats);
+      if (isstring (value))
+        value = cellstr (value(:))';
+      elseif (ischar (value))
+        value = {value};
+      endif
+      if (iscellstr (value))
+        [found, idx] = ismember (value, obj.VarNames);
+        if (! all (found))
+          error ("anova: %s contains an unknown factor name.", option);
+        endif
+        idx = idx(:)';
+        return;
+      endif
+      if (! isnumeric (value) || ! isvector (value) ...
+          || any (value != fix (value)) || any (value < 1) ...
+          || any (value > obj.nFactors_))
+        error ("anova: %s must contain valid factor indices.", option);
+      endif
+      idx = unique (value(:)', "stable");
     endfunction
 
     function obj = setFormula_ (obj)
-      if (isempty (obj.FactorNames))
-        obj.FactorNames = arrayfun (@(k) sprintf ("Factor%d", k), ...
-                                    1:obj.nFactors_, ...
-                                    'UniformOutput', false);
-        obj.VarNames = obj.FactorNames;
-      elseif (numel (obj.FactorNames) != obj.nFactors_)
+      if (isempty (obj.VarNames))
+        obj.VarNames = arrayfun (@(k) sprintf ("Factor%d", k), ...
+                                 1:obj.nFactors_, "UniformOutput", false);
+        obj.FactorNames = string (obj.VarNames);
+      elseif (numel (obj.VarNames) != obj.nFactors_)
         error ("anova: FactorNames must contain one name per factor.");
       endif
-      if (obj.nFactors_ == 0)
-        obj.Formula = sprintf ("%s ~ 1", obj.ResponseName);
-      else
-        terms = obj.FactorNames(1:obj.nFactors_);
-        if (ischar (obj.ModelType) && obj.nFactors_ > 1)
-          if (strcmpi (obj.ModelType, 'interaction'))
-            for a = 1:obj.nFactors_ - 1
-              for b = a + 1:obj.nFactors_
-                terms{end + 1} = sprintf ("%s:%s", ...
-                                           obj.FactorNames{a}, ...
-                                           obj.FactorNames{b});
-              endfor
-            endfor
-          elseif (strcmpi (obj.ModelType, 'full'))
-            for mask = 1:(2 ^ obj.nFactors_ - 1)
-              idx = find (bitget (mask, 1:obj.nFactors_));
-              if (numel (idx) > 1)
-                terms{end + 1} = strjoin (obj.FactorNames(idx), ':');
-              endif
-            endfor
-          endif
+      if (ischar (obj.ModelType) ...
+          && ! isempty (strfind (obj.ModelType, "~")))
+        schema = parseWilkinsonFormula (obj.ModelType, "matrix");
+        if (! isscalar (schema.ResponseIdx))
+          error ("anova: ModelSpecification must contain one response.");
         endif
-        rhs = strjoin (terms, ' + ');
-        obj.Formula = sprintf ("%s ~ 1 + %s", obj.ResponseName, rhs);
+        response = schema.VariableNames{schema.ResponseIdx};
+        if (! strcmp (response, obj.ResponseName))
+          error (strcat ("anova: formula response must match", ...
+                         " ResponseName."));
+        endif
+        [schema_names, schema_model] = obj.schemaModel_ (schema);
+        [found, columns_] = ismember (obj.VarNames, schema_names);
+        if (! all (found))
+          error ("anova: formula must use names in FactorNames.");
+        endif
+        model = schema_model(:, columns_);
+        [model, obj.nesting_] = obj.nestedSpecification_ (...
+                                  obj.ModelType, obj.VarNames, model);
+        obj.ModelType = model;
+        obj.formulaTerms_ = model;
+        obj.formulaText_ = obj.ModelSpecification;
+        return;
       endif
+      if (obj.nFactors_ == 0)
+        obj.formulaTerms_ = zeros (0, 0);
+        obj.formulaText_ = sprintf ("%s ~ 1", obj.ResponseName);
+      else
+        if (ischar (obj.ModelType) ...
+            && obj.isPolynomialModel_ (obj.ModelType))
+          model = obj.polynomialTerms_ (obj.ModelType);
+          obj.ModelType = model;
+        else
+          model = obj.modelTerms_ (obj.ModelType);
+        endif
+        obj.formulaTerms_ = model;
+        terms = obj.formulaTermNames_ (model);
+        rhs = strjoin (terms, " + ");
+        obj.formulaText_ = sprintf ("%s ~ 1 + %s", obj.ResponseName, rhs);
+      endif
+    endfunction
+
+    function model = modelTerms_ (obj, specification)
+      if (isnumeric (specification) && ! isscalar (specification))
+        model = specification;
+        return;
+      endif
+      if (isnumeric (specification))
+        max_order = min (specification, obj.nFactors_);
+      elseif (strcmpi (specification, "linear"))
+        max_order = 1;
+      elseif (strcmpi (specification, "interaction"))
+        max_order = min (2, obj.nFactors_);
+      else
+        max_order = obj.nFactors_;
+      endif
+      model = zeros (0, obj.nFactors_);
+      for order = 1:max_order
+        combinations = nchoosek (1:obj.nFactors_, order);
+        block = zeros (rows (combinations), obj.nFactors_);
+        for row = 1:rows (combinations)
+          block(row, combinations(row, :)) = 1;
+        endfor
+        model = [model; block];
+      endfor
+    endfunction
+
+    function names = formulaTermNames_ (obj, model)
+      names = obj.termNames_ (model);
+      if (isempty (obj.nesting_))
+        return;
+      endif
+      for factor = find (any (obj.nesting_, 2))'
+        parents = find (obj.nesting_(factor, :));
+        nested = sprintf ("%s(%s)", obj.VarNames{factor}, ...
+                          strjoin (obj.VarNames(parents), ","));
+        for term = find (model(:, factor) > 0)'
+          names{term} = strrep (names{term}, obj.VarNames{factor}, nested);
+        endfor
+      endfor
+    endfunction
+
+    function obj = updateFormula_ (obj)
+      separator = strfind (obj.formulaText_, "~");
+      if (isempty (separator))
+        linear_predictor = obj.formulaText_;
+      else
+        linear_predictor = strtrim (obj.formulaText_(separator(1) + 1:end));
+      endif
+      term_names = obj.formulaTermNames_ (obj.formulaTerms_);
+      nesting = obj.nesting_;
+      if (isempty (nesting))
+        nesting = false (obj.nFactors_);
+      endif
+      obj.Formula = struct (...
+        "ResponseName", string (obj.ResponseName), ...
+        "PredictorNames", string (obj.VarNames), ...
+        "Terms", obj.formulaTerms_, ...
+        "TermNames", string (term_names(:)), ...
+        "HasIntercept", true, ...
+        "Nesting", logical (nesting), ...
+        "LinearPredictor", string (linear_predictor), ...
+        "Text", string (obj.formulaText_));
+    endfunction
+
+    function tf = isPolynomialModel_ (obj, model)
+      tf = any (strcmpi (model, {"purequadratic", "quadratic"})) ...
+           || ! isempty (regexp (lower (model), '^poly[0-9]+$', 'once'));
+    endfunction
+
+    function model = polynomialTerms_ (obj, specification)
+      n = obj.nFactors_;
+      if (strcmpi (specification, "purequadratic"))
+        model = [eye(n); 2 * eye(n)];
+        return;
+      elseif (strcmpi (specification, "quadratic"))
+        interactions = zeros (0, n);
+        if (n > 1)
+          pairs = nchoosek (1:n, 2);
+          interactions = zeros (rows (pairs), n);
+          for i = 1:rows (pairs)
+            interactions(i, pairs(i, :)) = 1;
+          endfor
+        endif
+        model = [eye(n); interactions; 2 * eye(n)];
+        return;
+      endif
+
+      degrees = specification(5:end) - '0';
+      if (numel (degrees) != n)
+        error (strcat ("anova: polyIJK must specify one degree per", ...
+                       " factor."));
+      endif
+      model = [];
+      for factor = 1:n
+        for exponent = 1:degrees(factor)
+          row = zeros (1, n);
+          row(factor) = exponent;
+          model(end + 1, :) = row;
+        endfor
+      endfor
+      grids = cell (1, n);
+      ranges = arrayfun (@(d) 0:d, degrees, "UniformOutput", false);
+      [grids{:}] = ndgrid (ranges{:});
+      combinations = cell2mat (cellfun (@(g) g(:), grids, ...
+                                        "UniformOutput", false));
+      interactions = combinations(sum (combinations > 0, 2) > 1 ...
+                                  & sum (combinations, 2) <= max (degrees), :);
+      model = [model; interactions];
+    endfunction
+
+    function names = termNames_ (obj, model)
+      names = cell (rows (model), 1);
+      for row = 1:rows (model)
+        pieces = {};
+        for column = find (model(row, :) != 0)
+          exponent = model(row, column);
+          if (exponent == 1)
+            pieces{end + 1} = obj.VarNames{column};
+          else
+            pieces{end + 1} = sprintf ("%s^%d", ...
+                                       obj.VarNames{column}, exponent);
+          endif
+        endfor
+        names{row} = strjoin (pieces, ":");
+      endfor
     endfunction
 
     function alpha = parseAlpha_ (obj, varargin)
@@ -867,11 +1536,254 @@ classdef anova
       endif
     endfunction
 
+    function [stats_, args, sidak_alpha, dims] = comparisonArguments_ (...
+                                                        obj, varargin)
+      factors = {};
+      option_names = {"alpha", "criticalvaluetype", "approximate", ...
+                      "controlgroup", "display", "displayopt", ...
+                      "estimate"};
+      if (! isempty (varargin))
+        first = varargin{1};
+        is_option = obj.isName_ (first) ...
+                    && any (strcmpi (char (first), option_names));
+        if ((iscellstr (first) || isstring (first) || ischar (first)) ...
+            && ! is_option)
+          factors = first;
+          varargin(1) = [];
+        endif
+      endif
+      if (isempty (factors))
+        if (obj.NumFactors != 1)
+          error (strcat ("anova.multcompare: factors must be specified for", ...
+                         " a multi-factor ANOVA."));
+        endif
+        dims = 1;
+      else
+        dims = obj.factorIndices_ (factors);
+      endif
+      if (mod (numel (varargin), 2) != 0)
+        error ("anova.multcompare: name-value pairs must come in pairs.");
+      endif
+
+      alpha = 0.05;
+      ctype = "tukey-kramer";
+      has_approximate = false;
+      has_control = false;
+      args = {"display", "off"};
+      for k = 1:2:numel (varargin)
+        if (! obj.isName_ (varargin{k}))
+          error ("anova.multcompare: parameter name must be text.");
+        endif
+        name = lower (char (varargin{k}));
+        value = varargin{k + 1};
+        switch (name)
+          case "alpha"
+            alpha = value;
+          case "criticalvaluetype"
+            if (! obj.isName_ (value))
+              error ("anova.multcompare: CriticalValueType must be text.");
+            endif
+            ctype = lower (char (value));
+          case "approximate"
+            if (! ((islogical (value) || isnumeric (value)) ...
+                   && isscalar (value) && any (value == [0, 1])))
+              error (strcat ("anova.multcompare: Approximate must be a", ...
+                             " logical scalar."));
+            endif
+            has_approximate = true;
+          case "controlgroup"
+            has_control = true;
+            args = [args, {"controlgroup", value}];
+          case {"display", "displayopt", "estimate"}
+            args = [args, {name, value}];
+          otherwise
+            error ("anova.multcompare: parameter '%s' is not supported.", ...
+                   varargin{k});
+        endswitch
+      endfor
+      if (! (isnumeric (alpha) && isscalar (alpha) ...
+             && alpha > 0 && alpha < 1))
+        error ("anova.multcompare: Alpha must be a numeric scalar in (0, 1).");
+      endif
+      supported = {"tukey-kramer", "hsd", "dunn-sidak", ...
+                   "bonferroni", "scheffe", "dunnett", "lsd"};
+      if (! any (strcmp (ctype, supported)))
+        error ("anova.multcompare: unsupported CriticalValueType '%s'.", ...
+               ctype);
+      endif
+      if ((has_approximate || has_control) && ! strcmp (ctype, "dunnett"))
+        error (strcat ("anova.multcompare: Approximate and ControlGroup", ...
+                       " require CriticalValueType 'dunnett'."));
+      endif
+      if (strcmp (ctype, "dunnett") && numel (dims) != 1)
+        error ("anova.multcompare: Dunnett's test requires one factor.");
+      endif
+      sidak_alpha = [];
+      if (strcmp (ctype, "dunn-sidak"))
+        sidak_alpha = alpha;
+        ctype = "lsd";
+      endif
+      args = [args, {"alpha", alpha, "criticalvaluetype", ctype}];
+
+      stats_ = obj.Stats;
+      if (strcmp (obj.backend_, "anova2"))
+        if (numel (dims) == 1)
+          estimate = "column";
+          if (dims == 2)
+            estimate = "row";
+          endif
+          args = obj.replaceOption_ (args, "estimate", estimate);
+        else
+          [y, groups] = obj.anova2Data_ ();
+          [~, ~, stats_] = anovan (y, groups, obj.buildAnovanArgs_ (){:});
+          args = [args, {"dim", dims}];
+        endif
+      elseif (strcmp (obj.backend_, "anovan"))
+        args = [args, {"dim", dims}];
+      endif
+    endfunction
+
+    function args = replaceOption_ (obj, args, option, value)
+      names = args(1:2:end);
+      idx = find (cellfun (@(x) obj.isName_ (x) ...
+                          && strcmpi (char (x), option), names), 1, "last");
+      if (isempty (idx))
+        args = [args, {option, value}];
+      else
+        args{2 * idx} = value;
+      endif
+    endfunction
+
+    function idx = factorIndices_ (obj, factors)
+      if (isstring (factors))
+        factors = cellstr (factors(:))';
+      elseif (ischar (factors))
+        factors = {factors};
+      endif
+      if (! iscellstr (factors))
+        error ("anova.multcompare: factors must be factor names.");
+      endif
+      [found, idx] = ismember (factors, obj.VarNames);
+      if (! all (found) || isempty (idx))
+        error ("anova.multcompare: factors contains an unknown factor name.");
+      endif
+      idx = idx(:)';
+    endfunction
+
+    function [y, groups] = anova2Data_ (obj)
+      [nr, nc] = size (obj.Response);
+      nlevels = nr / obj.reps_;
+      y = obj.Response(:);
+      column_factor = kron ((1:nc)', ones (nr, 1));
+      row_factor = repmat (kron ((1:nlevels)', ones (obj.reps_, 1)), ...
+                           nc, 1);
+      groups = {column_factor, row_factor};
+    endfunction
+
+    function out = comparisonTable_ (obj, C, group_names, dims)
+      if (istable (group_names))
+        if (numel (dims) == 1)
+          group1 = group_names{C(:, 1), 1};
+          group2 = group_names{C(:, 2), 1};
+          if (ischar (group1) && rows (group1) > 1)
+            group1 = cellstr (group1);
+            group2 = cellstr (group2);
+          endif
+        else
+          group1 = group_names(C(:, 1), :);
+          group2 = group_names(C(:, 2), :);
+        endif
+      else
+        group1 = obj.groupIdentifiers_ (group_names(C(:, 1)), dims);
+        group2 = obj.groupIdentifiers_ (group_names(C(:, 2)), dims);
+      endif
+      out = table (group1, group2, C(:, 4), C(:, 3), C(:, 5), C(:, 6), ...
+                   "VariableNames", {"Group1", "Group2", ...
+                   "MeanDifference", "MeanDifferenceLower", ...
+                   "MeanDifferenceUpper", "pValue"});
+    endfunction
+
+    function groups = comparisonGroups_ (obj, stats_, dims)
+      df = stats_.df;
+      offsets = 1 + cumsum (df);
+      terms = find (sum (stats_.terms(:,dims) > 0, 2) ...
+                    == sum (stats_.terms > 0, 2));
+      design = zeros (rows (stats_.X), columns (stats_.X));
+      design(:,1) = 1;
+      for term = terms'
+        columns_ = offsets(term) - df(term) + 1:offsets(term);
+        design(:,columns_) = stats_.X(:,columns_);
+      endfor
+      unique_design = unique (design, "rows", "stable");
+      rows_ = zeros (rows (unique_design), 1);
+      for i = 1:rows (unique_design)
+        rows_(i) = find (all (design == unique_design(i,:), 2), 1);
+      endfor
+      selected = obj.Factors(rows_, obj.VarNames(dims));
+      groups = selected;
+    endfunction
+
+    function groups = groupIdentifiers_ (obj, labels, dims)
+      labels = cellstr (labels);
+      if (isempty (labels))
+        groups = obj.convertGroupValues_ (cell (0, 1), dims(1));
+        return;
+      endif
+      parts = cellfun (@(x) strsplit (x, ", "), labels, ...
+                       "UniformOutput", false);
+      widths = cellfun (@numel, parts);
+      has_names = ! any (widths != widths(1)) ...
+                  && all (cellfun (@(x) ! isempty (strfind (x, "=")), ...
+                                   [parts{:}]));
+      if (! has_names)
+        parts = cellfun (@(x) {x}, labels, "UniformOutput", false);
+        widths(:) = 1;
+      endif
+      values = cell (numel (labels), widths(1));
+      for i = 1:numel (labels)
+        for j = 1:widths(1)
+          if (has_names)
+            separator = strfind (parts{i}{j}, "=");
+            value = parts{i}{j}(separator(1) + 1:end);
+          else
+            value = parts{i}{j};
+          endif
+          values{i, j} = strtrim (value);
+        endfor
+      endfor
+      if (widths(1) == 1)
+        groups = obj.convertGroupValues_ (values(:, 1), dims(1));
+      else
+        columns_ = cell (1, widths(1));
+        for j = 1:widths(1)
+          columns_{j} = obj.convertGroupValues_ (values(:, j), dims(j));
+        endfor
+        groups = table (columns_{:}, ...
+                        "VariableNames", obj.VarNames(dims));
+      endif
+    endfunction
+
+    function values = convertGroupValues_ (obj, text_values, dim)
+      original = obj.Factors{:, obj.VarNames{dim}};
+      if (islogical (original))
+        values = strcmpi (text_values, "true") ...
+                 | strcmp (text_values, "1");
+      elseif (isnumeric (original))
+        values = cellfun (@str2double, text_values);
+      elseif (iscategorical (original))
+        values = categorical (text_values, categories (original));
+      elseif (isstring (original))
+        values = string (text_values);
+      else
+        values = text_values;
+      endif
+    endfunction
+
     function [G, names] = selectedFactorMatrix_ (obj, factors)
       if (ischar (factors))
-        idx = find (strcmp (obj.FactorNames, factors));
+        idx = find (strcmp (obj.VarNames, factors));
       elseif (iscellstr (factors))
-        idx = cellfun (@(s) find (strcmp (obj.FactorNames, s), 1), factors);
+        idx = cellfun (@(s) find (strcmp (obj.VarNames, s), 1), factors);
       else
         idx = factors;
       endif
@@ -883,8 +1795,8 @@ classdef anova
       if (any (idx < 1) || any (idx > obj.NumFactors))
         error ("anova: factor index exceeds the number of factors.");
       endif
-      if (isempty (obj.GROUP) && ! isvector (obj.Y))
-        [n, m] = size (obj.Y);
+      if (isempty (obj.GROUP) && ! isvector (obj.Response))
+        [n, m] = size (obj.Response);
         group_arg = reshape (repmat ((1:m), n, 1), [], 1);
         G = group_arg(:, idx);
       elseif (iscell (obj.GROUP) ...
@@ -896,12 +1808,12 @@ classdef anova
       else
         G = obj.GROUP(:, idx);
       endif
-      names = obj.FactorNames(idx);
+      names = obj.VarNames(idx);
     endfunction
 
     function name = factorName_ (obj, idx)
-      if (idx >= 1 && idx <= numel (obj.FactorNames))
-        name = obj.FactorNames{idx};
+      if (idx >= 1 && idx <= numel (obj.VarNames))
+        name = obj.VarNames{idx};
       else
         name = sprintf ("Factor%d", idx);
       endif
@@ -1023,7 +1935,7 @@ classdef anova
                        " for LinearModel input."));
       endif
 
-      atab = obj.componentStats_ (sstype);
+      [atab, stats_] = obj.componentFit_ (sstype);
       sources = obj.publicSourceNames_ (atab(2:end-1, 1));
       nterms = numel (sources) - 1;
       term_names = sources(1:nterms);
@@ -1031,13 +1943,13 @@ classdef anova
       q_coeff = ones (nterms, 1);
       variance_coeff = zeros (nterms, nterms);
 
-      if (strcmp (obj.backend_, "anovan") && isfield (obj.Stats, "terms"))
-        terms = obj.Stats.terms;
+      if (strcmp (obj.backend_, "anovan") && isfield (stats_, "terms"))
+        terms = stats_.terms;
         if (! isempty (obj.RandomFactors))
-          is_random = any (terms(:, obj.RandomFactors), 2);
+          is_random = obj.randomTermMask_ (terms, stats_);
         endif
-        [q_coeff, variance_coeff] = obj.emsCoefficients_ (terms, sstype, ...
-                                                          is_random);
+        [q_coeff, variance_coeff] = obj.emsCoefficients_ (stats_, terms, ...
+                                                          sstype, is_random);
       elseif (strcmp (obj.backend_, "anova1"))
         [q_coeff(1), variance_coeff(1, 1)] = obj.oneWayEmsCoefficient_ ();
         is_random(1) = any (obj.RandomFactors == 1);
@@ -1067,9 +1979,15 @@ classdef anova
       types{end} = "random";
       formulas{end} = "V(Error)";
 
-      denominator_ms = [repmat(obj.MSE, nterms, 1); NaN];
-      denominator_df = [repmat(obj.DFE, nterms, 1); NaN];
-      denominator_formula = [repmat({"MS(Error)"}, nterms, 1); {""}];
+      [term_ms, term_df, error_ms, error_df] = obj.meanSquareData_ (atab);
+      error_ms = obj.MSE;
+      error_df = obj.DFE;
+      [denominator_ms, denominator_df, denominator_formula] = ...
+        obj.denominatorData_ (variance_coeff, is_random, term_ms, ...
+                              term_df, error_ms, error_df, term_names);
+      denominator_ms(end + 1, 1) = NaN;
+      denominator_df(end + 1, 1) = NaN;
+      denominator_formula{end + 1, 1} = "";
       row_names = [term_names; {"Error"}];
       ems = table (string (types), string (formulas), denominator_ms, ...
                    denominator_df, string (denominator_formula), ...
@@ -1084,28 +2002,28 @@ classdef anova
       if (strcmp (obj.backend_, "anova1") && ! isempty (names))
         idx = find (strcmpi (names, "Groups"), 1);
         if (! isempty (idx))
-          names{idx} = obj.FactorNames{1};
+          names{idx} = obj.VarNames{1};
         endif
       elseif (strcmp (obj.backend_, "anova2"))
         idx = find (strcmpi (names, "Columns"), 1);
         if (! isempty (idx))
-          names{idx} = obj.FactorNames{1};
+          names{idx} = obj.VarNames{1};
         endif
         idx = find (strcmpi (names, "Rows"), 1);
         if (! isempty (idx))
-          names{idx} = obj.FactorNames{2};
+          names{idx} = obj.VarNames{2};
         endif
         idx = find (strcmpi (names, "Interaction"), 1);
         if (! isempty (idx))
-          names{idx} = sprintf ("%s:%s", obj.FactorNames{:});
+          names{idx} = sprintf ("%s:%s", obj.VarNames{:});
         endif
       endif
     endfunction
 
-    function [q_coeff, variance_coeff] = emsCoefficients_ (obj, terms, ...
-                                                           sstype, is_random)
-      X = full (obj.Stats.X);
-      dfs = obj.Stats.df(:);
+    function [q_coeff, variance_coeff] = emsCoefficients_ (obj, stats_, ...
+                                            terms, sstype, is_random)
+      X = full (stats_.X);
+      dfs = stats_.df(:);
       nterms = rows (terms);
       blocks = cell (nterms, 1);
       first = 2;
@@ -1116,8 +2034,14 @@ classdef anova
       bases = cell (nterms, 1);
       for i = 1:nterms
         factors = find (terms(i, :));
+        if (isfield (stats_, "vnested") && ! isempty (stats_.vnested))
+          nested = factors(any (stats_.vnested(factors,:), 2));
+          if (! isempty (nested))
+            factors = union (factors, find (any (stats_.vnested(nested,:), 1)));
+          endif
+        endif
         if (all (! ismember (factors, obj.Continuous)))
-          [~, ~, ids] = unique (obj.Stats.grps(:, factors), "rows");
+          [~, ~, ids] = unique (stats_.grps(:, factors), "rows");
           bases{i} = sparse (1:numel (ids), ids, 1);
         else
           bases{i} = X(:, blocks{i});
@@ -1137,6 +2061,140 @@ classdef anova
       endfor
     endfunction
 
+    function [term_ms, term_df, error_ms, error_df] = ...
+              meanSquareData_ (obj, atab)
+      source_col = obj.findAtabColumn_ (atab, {"Source"});
+      ms_col = obj.findAtabColumn_ (atab, ...
+                                    {"MeanSquares", "Mean Sq.", ...
+                                     "Mean Sq", "MS"});
+      df_col = obj.findAtabColumn_ (atab, {"DF", "d.f.", "df"});
+      sources = atab(2:end, source_col);
+      error_row = find (strcmpi (sources, "Error"), 1);
+      total_row = find (strcmpi (sources, "Total"), 1);
+      term_rows = setdiff (1:numel (sources), [error_row, total_row], ...
+                           "stable");
+      term_ms = cell2mat (atab(term_rows + 1, ms_col));
+      term_df = cell2mat (atab(term_rows + 1, df_col));
+      error_ms = atab{error_row + 1, ms_col};
+      error_df = atab{error_row + 1, df_col};
+    endfunction
+
+    function [denominator_ms, denominator_df, formulas] = ...
+              denominatorData_ (obj, variance_coeff, is_random, term_ms, ...
+                                term_df, error_ms, error_df, term_names)
+      nterms = numel (term_ms);
+      random_terms = find (is_random(:));
+      if (isempty (random_terms))
+        denominator_ms = repmat (error_ms, nterms, 1);
+        denominator_df = repmat (error_df, nterms, 1);
+        formulas = repmat ({"MS(Error)"}, nterms, 1);
+        return;
+      endif
+      random_ms = [term_ms(random_terms); error_ms];
+      random_df = [term_df(random_terms); error_df];
+      coefficients = [variance_coeff(random_terms, random_terms), ...
+                      ones(numel (random_terms), 1);
+                      zeros(1, numel (random_terms)), 1];
+      names = [term_names(random_terms); {"Error"}];
+      denominator_ms = zeros (nterms, 1);
+      denominator_df = zeros (nterms, 1);
+      formulas = cell (nterms, 1);
+      for i = 1:nterms
+        target = [variance_coeff(i, random_terms), 1];
+        own = find (random_terms == i, 1);
+        if (! isempty (own))
+          target(own) = 0;
+        endif
+        weights = pinv (coefficients') * target';
+        denominator_ms(i) = weights' * random_ms;
+        denominator_df(i) = denominator_ms(i) ^ 2 ...
+                            / sum ((weights .* random_ms) .^ 2 ./ random_df);
+        formulas{i} = obj.meanSquareFormula_ (weights, names);
+      endfor
+    endfunction
+
+    function formula = meanSquareFormula_ (obj, weights, names)
+      pieces = {};
+      for i = 1:numel (weights)
+        coefficient = weights(i);
+        if (abs (coefficient) <= 1e-10)
+          continue;
+        elseif (abs (coefficient - 1) <= 1e-10)
+          term = sprintf ("MS(%s)", names{i});
+        elseif (abs (coefficient + 1) <= 1e-10)
+          term = sprintf ("-MS(%s)", names{i});
+        else
+          term = sprintf ("%.6g*MS(%s)", coefficient, names{i});
+        endif
+        if (! isempty (pieces) && coefficient > 0)
+          term = ["+", term];
+        endif
+        pieces{end + 1} = term;
+      endfor
+      formula = strjoin (pieces, "");
+    endfunction
+
+    function [coefficients, mean_squares, dfs, names] = ...
+              varianceSystem_ (obj, stats_, atab, sstype)
+      [term_ms, term_df, error_ms, error_df] = obj.meanSquareData_ (atab);
+      sources = obj.publicSourceNames_ (atab(2:end-1, 1));
+      term_names = sources(1:numel (term_ms));
+      is_random = false (numel (term_ms), 1);
+      variance_coeff = zeros (numel (term_ms));
+      if (! isempty (obj.RandomFactors))
+        if (strcmp (obj.backend_, "anovan") && isfield (stats_, "terms"))
+          terms = stats_.terms;
+          is_random = obj.randomTermMask_ (terms, stats_);
+          [~, variance_coeff] = obj.emsCoefficients_ (stats_, terms, ...
+                                                       sstype, is_random);
+        elseif (strcmp (obj.backend_, "anova1"))
+          is_random(1) = true;
+          [~, variance_coeff(1, 1)] = obj.oneWayEmsCoefficient_ ();
+        endif
+      endif
+      random_terms = find (is_random);
+      coefficients = [variance_coeff(random_terms, random_terms), ...
+                      ones(numel (random_terms), 1);
+                      zeros(1, numel (random_terms)), 1];
+      mean_squares = [term_ms(random_terms); error_ms];
+      dfs = [term_df(random_terms); error_df];
+      names = [term_names(random_terms); {"Error"}];
+    endfunction
+
+    function atab = applyRandomInference_ (obj, atab, stats_, sstype)
+      if (isempty (obj.RandomFactors) || ! isfield (stats_, "terms"))
+        return;
+      endif
+      terms = stats_.terms;
+      is_random = obj.randomTermMask_ (terms, stats_);
+      [~, variance_coeff] = obj.emsCoefficients_ (stats_, terms, ...
+                                                   sstype, is_random);
+      [term_ms, term_df, error_ms, error_df] = obj.meanSquareData_ (atab);
+      names = obj.publicSourceNames_ (atab(2:rows (terms) + 1, 1));
+      [denominator_ms, denominator_df] = obj.denominatorData_ (...
+          variance_coeff, is_random, term_ms, term_df, error_ms, ...
+          error_df, names);
+      f_col = obj.findAtabColumn_ (atab, {"F"});
+      p_col = obj.findAtabColumn_ (atab, {"pValue", "Prob>F"});
+      f_stat = term_ms ./ denominator_ms;
+      p_value = fcdf (f_stat, term_df, denominator_df, "upper");
+      atab(2:numel (term_ms) + 1, f_col) = num2cell (f_stat);
+      atab(2:numel (term_ms) + 1, p_col) = num2cell (p_value);
+    endfunction
+
+    function is_random = randomTermMask_ (obj, terms, stats_)
+      membership = terms > 0;
+      if (isfield (stats_, "vnested") && ! isempty (stats_.vnested))
+        for factor = 1:columns (membership)
+          parents = find (stats_.vnested(factor,:));
+          if (! isempty (parents))
+            membership(:, parents) |= membership(:, factor);
+          endif
+        endfor
+      endif
+      is_random = any (membership(:, obj.RandomFactors), 2);
+    endfunction
+
     function [included, excluded] = emsModels_ (obj, X, blocks, terms, ...
                                                 term, sstype)
       nterms = numel (blocks);
@@ -1144,9 +2202,15 @@ classdef anova
         case 1
           included_terms = 1:term;
           excluded_terms = 1:term-1;
-        case {2, "h"}
+        case 2
           factors = find (terms(term, :));
-          excluded_terms = find (any (! terms(:, factors), 2))';
+          excluded_terms = find (any (terms(:, factors) ...
+                                      != terms(term, factors), 2))';
+          included_terms = [term, excluded_terms];
+        case "h"
+          factors = find (terms(term, :));
+          excluded_terms = find (any (terms(:, factors) ...
+                                      < terms(term, factors), 2))';
           included_terms = [term, excluded_terms];
         otherwise
           included_terms = 1:nterms;
@@ -1168,10 +2232,10 @@ classdef anova
     endfunction
 
     function [q_coeff, variance_coeff] = oneWayEmsCoefficient_ (obj)
-      if (isvector (obj.Y))
+      if (isvector (obj.Response))
         group = obj.GROUP(:);
       else
-        [n, groups] = size (obj.Y);
+        [n, groups] = size (obj.Response);
         group = reshape (repmat (1:groups, n, 1), [], 1);
       endif
       [~, ~, ids] = unique (group, "stable");
@@ -1223,32 +2287,43 @@ classdef anova
       obj.NumFactors = obj.nFactors_;
       obj.ModelSpecification = mdl.Formula.Terms;
       obj.ModelType = mdl.Formula.Terms;
-      obj.FactorNames = mdl.PredictorNames;
-      obj.VarNames = mdl.PredictorNames;
+      obj.VarNames = cellstr (mdl.PredictorNames);
+      obj.FactorNames = string (obj.VarNames);
+      obj.SumOfSquaresType = string (obj.SumOfSquaresType);
       obj.ResponseName = mdl.ResponseName;
-      obj.Formula = mdl.Formula.LinearPredictor;
+      obj.formulaTerms_ = mdl.Formula.Terms;
+      linear_predictor = char (mdl.Formula.LinearPredictor);
+      if (isempty (strfind (linear_predictor, "~")))
+        obj.formulaText_ = sprintf ("%s ~ %s", obj.ResponseName, ...
+                                    linear_predictor);
+      else
+        obj.formulaText_ = linear_predictor;
+      endif
+      obj.updateFormula_ ();
       obj.Y = mdl.Variables{:, mdl.ResponseName};
       obj.GROUP = mdl.Variables(:, mdl.PredictorNames);
       obj.Factors = obj.GROUP;
       obj.ExpandedFactorNames = mdl.CoefficientNames;
       obj.NumObservations = numel (obj.Y);
-      obj.Coefficients = obj.linearModelCoefficients_ (mdl);
+      obj.coefficientStats_ = obj.linearModelCoefficients_ (mdl);
+      obj.Coefficients = obj.coefficientStats_(:, 1);
       obj.AnovaTable = obj.linearModelAtab_ (mdl);
+      obj.rawResiduals_ = mdl.Residuals.Raw;
       obj.FittedValues = mdl.Fitted;
       obj.DFE = mdl.DFE;
       obj.MSE = mdl.MSE;
-      obj.rawResiduals_ = mdl.Residuals.Raw;
-      obj.Residuals = obj.residualsTable_ (obj.rawResiduals_);
+      obj.Residuals = obj.residualTable_ (obj.rawResiduals_, obj.MSE);
       obj.DesignMatrix = [];
       obj.Stats = obj.linearModelStats_ (mdl);
-      obj.Metrics = obj.metricsTable_ ();
+      obj.updatePublicResults_ ();
       obj.fitted_ = true;
       obj.dirty_ = false;
     endfunction
 
     function validateSpec_ (obj)
-      if (! (isnumeric (obj.SSType) && isscalar (obj.SSType) ...
-             && any (obj.SSType == [1, 2, 3])))
+      if (! ((isnumeric (obj.SSType) && isscalar (obj.SSType) ...
+              && any (obj.SSType == [1, 2, 3])) ...
+             || (ischar (obj.SSType) && strcmp (obj.SSType, "h"))))
         error (strcat ("anova: SumOfSquaresType must be 'one',", ...
                        " 'two', 'three', or 'hierarchical'."));
       endif
@@ -1264,13 +2339,26 @@ classdef anova
         if (! any (strcmpi (obj.ModelType, ...
                             {'linear', 'interaction', 'full'})))
           error (strcat ("anova: ModelSpecification must be 'linear',", ...
-                         " 'interactions', 'full', or a terms matrix."));
+                         " 'interactions', 'purequadratic', 'quadratic',", ...
+                         " 'polyIJK', 'full', or a terms matrix."));
         endif
       elseif (! isnumeric (obj.ModelType))
         error (strcat ("anova: ModelSpecification must be a string", ...
                        " or a numeric terms matrix."));
       endif
-      if (! iscellstr (obj.FactorNames))
+      if (isnumeric (obj.ModelType) && isscalar (obj.ModelType) ...
+          && (obj.ModelType != fix (obj.ModelType) || obj.ModelType < 1))
+        error (strcat ("anova: integer ModelSpecification must be a", ...
+                       " positive integer."));
+      endif
+      if (isnumeric (obj.ModelType) && ! isscalar (obj.ModelType) ...
+          && (any (! isfinite (obj.ModelType(:))) ...
+              || any (obj.ModelType(:) < 0) ...
+              || any (obj.ModelType(:) != fix (obj.ModelType(:)))))
+        error (strcat ("anova: terms matrix entries must be nonnegative", ...
+                       " integers."));
+      endif
+      if (! iscellstr (obj.VarNames))
         error ("anova: FactorNames must be a character vector or cellstr.");
       endif
       if (! obj.isName_ (obj.ResponseName))
@@ -1285,15 +2373,6 @@ classdef anova
               || any (obj.Continuous != fix (obj.Continuous)) ...
               || any (obj.Continuous < 1)))
         error ("anova: CategoricalFactors must contain valid factor indices.");
-      endif
-      if (! isempty (obj.RandomFactors) && ! isnumeric (obj.RandomFactors))
-        error ("anova: RandomFactors must be a numeric index vector.");
-      endif
-      if (! isempty (obj.RandomFactors) ...
-          && (! isvector (obj.RandomFactors) ...
-              || any (obj.RandomFactors != fix (obj.RandomFactors)) ...
-              || any (obj.RandomFactors < 1)))
-        error ("anova: RandomFactors must contain positive integer indices.");
       endif
       if (! isempty (obj.Weights) && ! isnumeric (obj.Weights))
         error ("anova: Weights must be numeric.");
@@ -1321,8 +2400,16 @@ classdef anova
         error ("anova: RandomFactors indices exceed the number of factors.");
       endif
       if (isnumeric (obj.ModelType) && ! isempty (obj.ModelType) ...
+          && ! isscalar (obj.ModelType) ...
           && columns (obj.ModelType) != obj.nFactors_)
         error ("anova: terms matrix must have one column per factor.");
+      endif
+      if (isnumeric (obj.ModelType) && ! isscalar (obj.ModelType))
+        powered = find (any (obj.ModelType > 1, 1));
+        if (any (ismember (powered, obj.CategoricalFactors)))
+          error (strcat ("anova: polynomial powers require continuous", ...
+                         " factors."));
+        endif
       endif
     endfunction
 
@@ -1331,9 +2418,13 @@ classdef anova
           && all (cellfun (@(c) isvector (c) || ischar (c), group(:))) ...
           && size (group, 1) == 1)
         for k = 1:numel (group)
-          if (numel (group{k}) != nobs)
-            error (strcat ("anova: GROUP variables must match the number", ...
-                           " of observations."));
+          if (ischar (group{k}) && rows (group{k}) > 1)
+            count = rows (group{k});
+          else
+            count = numel (group{k});
+          endif
+          if (count != nobs)
+            error ("anova: GROUP variables must match the number of observations.");
           endif
         endfor
       elseif (isvector (group))
@@ -1352,7 +2443,7 @@ classdef anova
     ## - GROUP is a 2-D numeric / cell matrix -> size (GROUP, 2)
     function nf = countFactors_ (obj)
       if (isempty (obj.GROUP))
-        if (ismatrix (obj.Y) && ! isvector (obj.Y))
+        if (ismatrix (obj.Response) && ! isvector (obj.Response))
           if (isempty (obj.reps_))
             nf = 1;
           else
@@ -1378,9 +2469,15 @@ classdef anova
     ##   anova1  : 1 factor, no continuous, no weights, SSType == 3
     ##   anovan  : everything else (full generality)
     function obj = selectBackend_ (obj)
-      if (! isempty (obj.reps_) && ismatrix (obj.Y) ...
-          && ! isvector (obj.Y) && ! any (isnan (obj.Y(:))) ...
-          && isempty (obj.Continuous) && isempty (obj.Weights))
+      anova2_model = ischar (obj.ModelType) ...
+                     && any (strcmpi (obj.ModelType, ...
+                                      {"linear", "interaction", "full"}));
+      if (! isempty (obj.reps_) && ismatrix (obj.Response) ...
+          && ! isvector (obj.Response) ...
+          && isempty (obj.Continuous) && isempty (obj.Weights) ...
+          && isempty (obj.RandomFactors) ...
+          && (isempty (obj.nesting_) || ! any (obj.nesting_(:))) ...
+          && anova2_model)
         obj.backend_ = 'anova2';
       elseif (obj.nFactors_ == 1 && isempty (obj.Continuous) ...
               && isempty (obj.Weights) && obj.SSType == 3)
@@ -1410,21 +2507,17 @@ classdef anova
         case 'linearmodel'
           ## Already populated from the supplied LinearModel object.
       endswitch
-      if (! strcmp (obj.backend_, 'linearmodel'))
-        obj.Metrics = obj.metricsTable_ ();
-      endif
+      obj = obj.updatePublicResults_ ();
       obj.fitted_ = true;
       obj.dirty_  = false;
     endfunction
 
     function obj = fitAnova1_ (obj)
-      ## Always run the anova1 backend silently; anova presents results through
-      ## its own summary, disp, and plotDiagnostics methods, so the backend must
-      ## not print a table or open its boxplot figure during a fit.
-      if (isvector (obj.Y))
-        [~, atab, stats] = anova1 (obj.Y, obj.GROUP, 'off');
+      ## Run the backend silently; this class owns display and plotting.
+      if (isvector (obj.Response))
+        [~, atab, stats] = anova1 (obj.Response, obj.GROUP, 'off');
       else
-        [~, atab, stats] = anova1 (obj.Y, [], 'off');
+        [~, atab, stats] = anova1 (obj.Response, [], 'off');
       endif
       obj.AnovaTable = atab;
       obj.Stats      = stats;
@@ -1439,26 +2532,43 @@ classdef anova
       if (ischar (obj.ModelType))
         modelarg = obj.ModelType;
       endif
-      ## Always run the anova2 backend silently; see fitAnova1_.
-      [~, atab, stats] = anova2 (obj.Y, obj.reps_, 'off', modelarg);
+      [~, atab, stats] = anova2 (obj.Response, obj.reps_, 'off', ...
+                                 modelarg);
       obj.AnovaTable = atab;
       obj.Stats      = stats;
-      obj.DFE        = stats.df;
-      obj.MSE        = stats.sigmasq;
-      ## anova2 does not return coeffs / resid / X.
+      if (isfield (stats, "source") && strcmp (stats.source, "anovan"))
+        obj.DFE = stats.dfe;
+        obj.MSE = stats.mse;
+        obj.coefficientStats_ = stats.coeffs;
+        obj.Coefficients = stats.coeffs(:, 1);
+        obj.DesignMatrix = stats.X;
+        obj.FittedValues = full (stats.X) * obj.Coefficients;
+        obj.rawResiduals_ = stats.Y - obj.FittedValues;
+        obj.Residuals = obj.residualTable_ (obj.rawResiduals_, obj.MSE);
+        obj.Y = stats.Y;
+        obj.Response = stats.Y;
+        obj.NumObservations = numel (stats.Y);
+        obj.GROUP = {stats.grps(:, 1), stats.grps(:, 2)};
+        obj.Factors = table (obj.GROUP{:}, "VariableNames", obj.VarNames);
+      else
+        obj.DFE = stats.df;
+        obj.MSE = stats.sigmasq;
+        ## Balanced anova2 does not expose coefficients or residuals.
+      endif
     endfunction
 
     function obj = fitAnovan_ (obj)
       [y_vec, group_arg] = obj.anovanData_ ();
       [~, atab, stats] = anovan (y_vec, group_arg, ...
                                  obj.buildAnovanArgs_(){:});
-      obj.AnovaTable = atab;
+      obj.AnovaTable = obj.applyRandomInference_ (atab, stats, obj.SSType);
       obj.Stats      = stats;
       if (isfield (stats, 'coeffs'))
-        obj.Coefficients = stats.coeffs;
+        obj.coefficientStats_ = stats.coeffs;
+        obj.Coefficients = stats.coeffs(:, 1);
       endif
-      if (isfield (stats, 'coeffnames'))
-        obj.ExpandedFactorNames = cellstr (stats.coeffnames);
+      if (isfield (stats, 'resid'))
+        obj.rawResiduals_ = stats.resid;
       endif
       if (isfield (stats, 'X'))
         obj.DesignMatrix = stats.X;
@@ -1470,41 +2580,32 @@ classdef anova
         obj.MSE = stats.mse;
       endif
       if (! isempty (obj.DesignMatrix) && ! isempty (obj.Coefficients))
-        obj.FittedValues = full (obj.DesignMatrix) * obj.Coefficients(:, 1);
-        ## anovan drops observations with a missing (NaN) response or numeric
-        ## grouping value, so the design matrix (and fitted values) cover only
-        ## the retained rows.  Align the response with those rows before
-        ## differencing; expose raw (observed minus fitted) residuals so that
-        ## FittedValues + Residuals == Y over the retained observations.
-        keep = ! isnan (y_vec);
-        if (iscell (group_arg))
-          for k = 1:numel (group_arg)
-            if (isnumeric (group_arg{k}))
-              keep = keep & ! isnan (group_arg{k}(:));
-            endif
-          endfor
-        elseif (isnumeric (group_arg) && ! isempty (group_arg))
-          keep = keep & ! any (isnan (group_arg), 2);
-        endif
-        if (numel (obj.FittedValues) == sum (keep))
-          obj.rawResiduals_ = y_vec(keep) - obj.FittedValues;
-          obj.Residuals = obj.residualsTable_ (obj.rawResiduals_);
-        endif
+        obj.FittedValues = full (obj.DesignMatrix) * obj.Coefficients;
+        obj.rawResiduals_ = obj.Y - obj.FittedValues;
+      endif
+      if (! isempty (obj.rawResiduals_))
+        obj.Residuals = obj.residualTable_ (obj.rawResiduals_, obj.MSE);
       endif
     endfunction
 
     function atab = componentStats_ (obj, sstype)
+      [atab] = obj.componentFit_ (sstype);
+    endfunction
+
+    function [atab, stats_] = componentFit_ (obj, sstype)
       if (strcmp (obj.backend_, "linearmodel"))
         error ("anova.stats: component type is unavailable for LinearModel input.");
       endif
       if (strcmp (obj.backend_, "anova2"))
         obj.ensureFit_ ();
         atab = obj.AnovaTable;
+        stats_ = obj.Stats;
         return;
       endif
       [y_vec, group_arg] = obj.anovanData_ ();
       args = obj.buildAnovanArgs_ (sstype);
-      [~, atab] = anovan (y_vec, group_arg, args{:});
+      [~, atab, stats_] = anovan (y_vec, group_arg, args{:});
+      atab = obj.applyRandomInference_ (atab, stats_, sstype);
     endfunction
 
     function atab = summaryStats_ (obj)
@@ -1589,13 +2690,16 @@ classdef anova
     endfunction
 
     function [y_vec, group_arg] = anovanData_ (obj)
-      if (isempty (obj.GROUP) && ! isvector (obj.Y))
-        [n, m] = size (obj.Y);
-        y_vec = obj.Y(:);
+      if (! isempty (obj.reps_) && isempty (obj.GROUP) ...
+          && ! isvector (obj.Response))
+        [y_vec, group_arg] = obj.anova2Data_ ();
+      elseif (isempty (obj.GROUP) && ! isvector (obj.Response))
+        [n, m] = size (obj.Response);
+        y_vec = obj.Response(:);
         group = reshape (repmat (1:m, n, 1), [], 1);
         group_arg = {group};
       else
-        y_vec = obj.Y(:);
+        y_vec = obj.Response(:);
         group_arg = obj.GROUP;
         if (isempty (group_arg))
           group_arg = {};
@@ -1605,9 +2709,10 @@ classdef anova
 
     function s = sstypeLabel_ (obj)
       switch (obj.SSType)
-        case 1; s = 'I';
-        case 2; s = 'II';
-        otherwise; s = 'III';
+        case 1; s = "I";
+        case 2; s = "II";
+        case 3; s = "III";
+        otherwise; s = "hierarchical";
       endswitch
     endfunction
 
@@ -1656,9 +2761,11 @@ classdef anova
       if (! isempty (obj.Continuous))
         nv = [nv, {'continuous', obj.Continuous}];
       endif
-      if (! isempty (obj.Random))
-        nv = [nv, {'random', obj.Random}];
+      if (! isempty (obj.nesting_) && any (obj.nesting_(:)))
+        nv = [nv, {'nested', obj.nesting_}];
       endif
+      ## Random terms are retained so their expected mean squares can provide
+      ## the correct F denominators and variance component estimates.
       if (! isempty (obj.Weights))
         nv = [nv, {'weights', obj.Weights}];
       endif
@@ -1677,6 +2784,176 @@ classdef anova
       p = max (columns (obj.DesignMatrix), 1);
       D = (obj.rawResiduals_ .^ 2 ./ max (p * obj.MSE, eps)) ...
           .* leverage ./ max ((1 - leverage) .^ 2, eps);
+    endfunction
+
+    function residuals = residualTable_ (obj, raw, mse)
+      pearson = raw ./ sqrt (mse);
+      residuals = table (raw(:), pearson(:), "VariableNames", ...
+                         {"Raw", "Pearson"});
+    endfunction
+
+    function obj = updatePublicResults_ (obj)
+      if (strcmp (obj.backend_, "anovan") ...
+          && ! isempty (obj.coefficientStats_))
+        [obj.Coefficients, names] = obj.expandedCoefficients_ ();
+        obj.ExpandedFactorNames = string (names);
+      elseif (strcmp (obj.backend_, "anova1"))
+        obj = obj.populateOneWayResults_ ();
+      elseif (isfield (obj.Stats, "coeffnames") ...
+              && numel (obj.Stats.coeffnames) == numel (obj.Coefficients))
+        obj.ExpandedFactorNames = string (obj.Stats.coeffnames(:));
+      elseif (! isempty (obj.Coefficients))
+        names = arrayfun (@(k) sprintf ("Coefficient%d", k), ...
+                          (1:numel (obj.Coefficients))', ...
+                          "UniformOutput", false);
+        obj.ExpandedFactorNames = string (names);
+      endif
+      if (isempty (obj.AnovaTable) || isempty (obj.MSE))
+        return;
+      endif
+      source = obj.findAtabColumn_ (obj.AnovaTable, {"Source"});
+      ss = obj.findAtabColumn_ (obj.AnovaTable, ...
+                                {"SumOfSquares", "Sum Sq.", "Sum Sq", ...
+                                 "SS"});
+      df = obj.findAtabColumn_ (obj.AnovaTable, {"DF", "d.f.", "df"});
+      names = obj.AnovaTable(2:end, source);
+      error_row = find (strcmpi (names, "Error"), 1) + 1;
+      total_row = find (strcmpi (names, "Total"), 1) + 1;
+      if (isempty (error_row) || isempty (total_row))
+        return;
+      endif
+      sse = obj.AnovaTable{error_row, ss};
+      sst = obj.AnovaTable{total_row, ss};
+      total_df = obj.AnovaTable{total_row, df};
+      if (isnumeric (total_df) && isscalar (total_df) && isfinite (total_df))
+        obj.NumObservations = total_df + 1;
+      endif
+      ssr = sst - sse;
+      if (sst == 0)
+        rsquared = NaN;
+        adjusted = NaN;
+      else
+        rsquared = ssr / sst;
+        adjusted = 1 - (obj.NumObservations - 1) * sse ...
+                       / (obj.DFE * sst);
+      endif
+      obj.Metrics = table (obj.MSE, sqrt (obj.MSE), sse, ssr, sst, ...
+                           rsquared, adjusted, "VariableNames", ...
+                           {"MSE", "RMSE", "SSE", "SSR", "SST", ...
+                            "RSquared", "AdjustedRSquared"});
+    endfunction
+
+    function [coefficients, names] = expandedCoefficients_ (obj)
+      coefficients = obj.coefficientStats_(1, 1);
+      names = {"(Intercept)"};
+      first = 2;
+      for term = 1:rows (obj.Stats.terms)
+        factors = find (obj.Stats.terms(term, :));
+        mapping = 1;
+        expanded_names = {""};
+        for factor = factors
+          if (any (factor == obj.Continuous))
+            contrast = 1;
+            factor_names = {obj.VarNames{factor}};
+          elseif (isfield (obj.Stats, "vnested") ...
+                  && any (obj.Stats.vnested(factor,:)))
+            [contrast, factor_names] = ...
+              obj.nestedCoefficientMap_ (factor);
+          else
+            contrast = obj.Stats.contrasts{factor};
+            levels = obj.Stats.grpnames{factor};
+            factor_names = cellfun (@(x) sprintf ("(%s==%s)", ...
+                                      obj.VarNames{factor}, ...
+                                      obj.levelText_ (x)), levels, ...
+                                     "UniformOutput", false);
+          endif
+          mapping = kron (mapping, contrast);
+          combined = cell (numel (expanded_names) * numel (factor_names), 1);
+          cursor = 1;
+          for left = 1:numel (expanded_names)
+            for right = 1:numel (factor_names)
+              if (isempty (expanded_names{left}))
+                combined{cursor} = factor_names{right};
+              else
+                combined{cursor} = sprintf ("%s:%s", ...
+                                             expanded_names{left}, ...
+                                             factor_names{right});
+              endif
+              cursor += 1;
+            endfor
+          endfor
+          expanded_names = combined;
+        endfor
+        width = obj.Stats.df(term);
+        compact = obj.coefficientStats_(first:first + width - 1, 1);
+        coefficients = [coefficients; mapping * compact];
+        names = [names; expanded_names];
+        first += width;
+      endfor
+    endfunction
+
+    function [mapping, names] = nestedCoefficientMap_ (obj, factor)
+      parents = find (obj.Stats.vnested(factor,:));
+      [parent_codes, ~, parent_id] = unique (...
+        obj.Stats.grps(:, parents), "rows", "stable");
+      mapping = zeros (0, 0);
+      names = {};
+      for parent = 1:rows (parent_codes)
+        rows_ = parent_id == parent;
+        child_codes = unique (obj.Stats.grps(rows_, factor), "stable");
+        nlevels = numel (child_codes);
+        contrast = [zeros(1, nlevels - 1); eye(nlevels - 1)] ...
+                   - 1 / nlevels;
+        mapping = blkdiag (mapping, contrast);
+        for child = child_codes(:)'
+          pieces = cell (1, numel (parents) + 1);
+          pieces{1} = sprintf ("(%s==%s)", obj.VarNames{factor}, ...
+                               obj.levelText_ (...
+                                 obj.Stats.grpnames{factor}{child}));
+          for k = 1:numel (parents)
+            code = parent_codes(parent, k);
+            pieces{k + 1} = sprintf ("(%s==%s)", ...
+                                     obj.VarNames{parents(k)}, ...
+                                     obj.levelText_ (...
+                                       obj.Stats.grpnames{parents(k)}{code}));
+          endfor
+          names{end + 1, 1} = strjoin (pieces, ":");
+        endfor
+      endfor
+    endfunction
+
+    function obj = populateOneWayResults_ (obj)
+      means = obj.Stats.means(:);
+      intercept = mean (means);
+      obj.Coefficients = [intercept; means - intercept];
+      level_names = cellfun (@(x) sprintf ("(%s==%s)", ...
+                              obj.VarNames{1}, obj.levelText_ (x)), ...
+                             obj.Stats.gnames(:), "UniformOutput", false);
+      obj.ExpandedFactorNames = string ([{"(Intercept)"}; level_names]);
+      if (isvector (obj.Response))
+        group_id = grp2idx (obj.GROUP);
+        fitted = NaN (size (group_id));
+        grouped = isfinite (group_id) & group_id > 0;
+        fitted(grouped) = means(group_id(grouped));
+      else
+        fitted = repmat (means', rows (obj.Response), 1);
+        fitted = fitted(:);
+      endif
+      valid = isfinite (obj.Y) & isfinite (fitted);
+      obj.FittedValues = NaN (size (obj.Y));
+      obj.FittedValues(valid) = fitted(valid);
+      obj.rawResiduals_ = obj.Y - obj.FittedValues;
+      obj.Residuals = obj.residualTable_ (obj.rawResiduals_, obj.MSE);
+    endfunction
+
+    function text = levelText_ (obj, value)
+      if (isnumeric (value) || islogical (value))
+        text = num2str (value);
+      elseif (isstring (value))
+        text = char (value);
+      else
+        text = value;
+      endif
     endfunction
 
     function h = plotDiagnostics_ (obj, residuals, fitted, leverage, ...
@@ -1961,8 +3238,8 @@ endclassdef
 %!test
 %! y = magic (4);
 %! a = anova (y);
-%! assert_equal (class (a), 'anova');
-%! assert_equal (a.Y, y);
+%! assert_equal (class (a), "anova");
+%! assert_equal (a.Y, y(:));
 %! assert_equal (a.GROUP, []);
 
 ## Basic construction: cell of two grouping vectors
@@ -1978,25 +3255,24 @@ endclassdef
 %!test
 %! a = anova ([1;1;2;2], [1;2;3;4]);
 %! assert_equal (a.ModelSpecification, 'linear');
-%! assert_equal (a.SumOfSquaresType, 'three');
+%! assert_equal (char (a.SumOfSquaresType), 'three');
 %! assert_equal (a.ResponseName, 'Y');
-%! assert_equal (a.FactorNames, {'Factor1'});
+%! assert_equal (cellstr (a.FactorNames), {'Factor1'});
 %! assert_equal (a.RandomFactors, []);
-%! assert_equal (a.CategoricalFactors, 'all');
+%! assert_equal (a.CategoricalFactors, 1);
 %! assert_equal (a.NumFactors, 1);
 %! assert_equal (a.NumObservations, 4);
 
-## Eager fit at construction populates the table statistics; the anova1
-## backend does not expose coefficients, residuals, fitted values, or a
-## design matrix, so those stay at their empty defaults
+## Eager one-way fits populate the derived public result properties.
 %!test
 %! a = anova ([1;1;2;2], [1;2;3;4]);
-%! assert_equal (isempty (a.AnovaTable), false);
-%! assert_equal (isempty (a.DFE), false);
-%! assert_equal (isempty (a.MSE), false);
-%! assert_equal (a.Coefficients, []);
-%! assert_equal (a.Residuals, []);
-%! assert_equal (a.FittedValues, []);
+%! assert_equal (a.Coefficients, [2.5; -1; 1], 1e-12);
+%! assert_equal (cellstr (a.ExpandedFactorNames), ...
+%!               {'(Intercept)'; '(Factor1==1)'; '(Factor1==2)'});
+%! assert_equal (a.FittedValues, [1.5; 1.5; 3.5; 3.5], 1e-12);
+%! assert_equal (a.Residuals.Raw, [-0.5; 0.5; -0.5; 0.5], 1e-12);
+%! assert_equal (a.Residuals.Pearson, ...
+%!               [-1; 1; -1; 1] / sqrt (2), 1e-12);
 %! assert_equal (a.DesignMatrix, []);
 
 ## Name-value parsing: MATLAB-compatible names
@@ -2006,15 +3282,14 @@ endclassdef
 %! g2 = repmat ([1;1;2;2], 3, 1);
 %! a = anova ({g1, g2}, y, 'SumOfSquaresType', 'two', ...
 %!            'ModelSpecification', 'full', 'FactorNames', {'A', 'B'});
-%! assert_equal (a.SumOfSquaresType, 'two');
+%! assert_equal (char (a.SumOfSquaresType), 'two');
 %! assert_equal (a.ModelSpecification, 'full');
-%! assert_equal (a.FactorNames, {'A', 'B'});
+%! assert_equal (cellstr (a.FactorNames), {'A', 'B'});
 
 ## Name-value parsing: case-insensitive names, displayopt alias
 %!test
-%! a = anova ([1;1;2;2], [1;2;3;4], 'SumOfSquaresType', 'one', ...
-%!            'displayopt', 'on');
-%! assert_equal (a.SumOfSquaresType, 'one');
+%! a = anova ([1;1;2;2], [1;2;3;4], 'SumOfSquaresType', 'one', 'displayopt', 'on');
+%! assert_equal (char (a.SumOfSquaresType), 'one');
 
 ## Display 'on' never reaches a backend: no fit prints a table or opens a
 ## figure.  The three constructions select the anova1, anova2, and anovan
@@ -2158,7 +3433,7 @@ endclassdef
 %! g = repmat ([1;2;3], 4, 1);
 %! a = anova ({g}, y, 'SumOfSquaresType', 'two', 'Alpha', 0.10);
 %! a.fit ();
-%! assert_equal (a.SumOfSquaresType, 'two');
+%! assert_equal (char (a.SumOfSquaresType), 'two');
 %! assert_equal (a.Stats.alpha, 0.10, 1e-12);
 
 ## --- Numeric references -------------------------------------------------
@@ -2188,7 +3463,8 @@ endclassdef
 %! g = [1; 1; 1; 2; 2; 2; 3; 3; 3];
 %! a = anova (g, y, 'SumOfSquaresType', 'two');
 %! assert_equal (predict (a), [2; 2; 2; 5; 5; 5; 11; 11; 11], 1e-12);
-%! assert_equal (a.Residuals.Raw, [-1; 0; 1; -1; 0; 1; -1; 0; 1], 1e-12);
+%! assert_equal (a.Residuals.Raw, ...
+%!               [-1; 0; 1; -1; 0; 1; -1; 0; 1], 1e-12);
 
 ## Effect sizes: reference eta2 = SS/SST, omega2 = (SS-df*MSE)/(SST+MSE).
 %!test
@@ -2220,12 +3496,12 @@ endclassdef
 %! y = [1; 2; 3; 4; 5; 6; 10; 11; 12];
 %! g = [1; 1; 1; 2; 2; 2; 3; 3; 3];
 %! a = anova (g, y, 'SumOfSquaresType', 'two');
-%! C = multcompare (a, 'display', 'off');
-%! assert_equal (C(:, 1:2), [1 2; 1 3; 2 3]);
-%! assert_equal (C(:, 4), [-3; -9; -6], 1e-12);
-%! assert_equal (C(1, 6), 0.010402, 1e-6);
-%! assert_equal (C(2, 6), 9.9474e-05, 1e-9);
-%! assert_equal (C(3, 6), 0.00064995, 1e-8);
+%! C = multcompare (a, 'CriticalValueType', 'bonferroni');
+%! assert_equal (istable (C), true);
+%! assert_equal (C.Group1, [1; 1; 2]);
+%! assert_equal (C.Group2, [2; 3; 3]);
+%! assert_equal (C.MeanDifference, [-3; -9; -6], 1e-12);
+%! assert_equal (all (C.pValue >= 0 & C.pValue <= 1), true);
 
 ## --- Week 3: summary / disp ---------------------------------------------
 
@@ -2262,43 +3538,51 @@ endclassdef
 
 ## --- Week 4: multcompare pass-through ----------------------------------
 
-## multcompare(): anovan backend returns a pairwise comparison matrix
+## multcompare(): anovan backend returns MATLAB's comparison table
 %!test
 %! y = [1; 2; 3; 4; 5; 6; 10; 11; 12];
 %! g = [1; 1; 1; 2; 2; 2; 3; 3; 3];
 %! a = anova (g, y, 'SumOfSquaresType', 'two');
-%! C = multcompare (a, 'display', 'off');
+%! C = multcompare (a);
 %! assert_equal (! isempty (C), true);
 %! assert_equal (size (C, 1), 3);        ## 3 pairwise comparisons for 3 groups
-%! assert_equal (size (C, 2) >= 6, true);  ## at least i,j,diff,lo,hi,p
+%! assert_equal (C.Properties.VariableNames, ...
+%!               {'Group1', 'Group2', 'MeanDifference', ...
+%!                'MeanDifferenceLower', 'MeanDifferenceUpper', 'pValue'});
 
 ## multcompare(): two-way balanced via anova2 backend
 %!test
 %! popcorn = [5.5, 4.5, 3.5; 5.5, 4.5, 4.0; 6.0, 4.0, 3.0; ...
 %!            6.5, 5.0, 4.0; 7.0, 5.5, 5.0; 7.0, 5.0, 4.5];
 %! a = anova (popcorn, [], 'reps', 3);
-%! C = multcompare (a, 'display', 'off', 'estimate', 'column');
+%! C = multcompare (a, 'Factor1');
 %! assert_equal (! isempty (C), true);
-%! assert_equal (size (C, 2) >= 6, true);
+%! assert_equal (width (C), 6);
 
 ## multcompare(): runs after a fresh construction (triggers ensureFit_)
 %!test
 %! a = anova ([1;1;2;2;3;3], (1:6)', 'SumOfSquaresType', 'two');
-%! C = multcompare (a, 'display', 'off');
+%! C = multcompare (a);
 %! assert_equal (! isempty (C), true);
 
 ## MATLAB-compatible public methods and properties
 %!test
 %! y = [1; 2; 3; 4; 5; 6; 10; 11; 12];
 %! g = [1; 1; 1; 2; 2; 2; 3; 3; 3];
-%! a = anova (g, y, 'FactorNames', {'Brand'}, ...
-%!            'ResponseName', 'Yield', 'SumOfSquaresType', 'two');
-%! assert_equal (a.Formula, 'Yield ~ 1 + Brand');
+%! a = anova (g, y, "FactorNames", {"Brand"}, ...
+%!            "ResponseName", "Yield", "SumOfSquaresType", "two");
+%! assert_equal (char (a.Formula.Text), "Yield ~ 1 + Brand");
+%! assert_equal (cellstr (a.Formula.PredictorNames), {"Brand"});
+%! assert_equal (a.Formula.Terms, 1);
+%! assert_equal (istable (a.Factors), true);
 %! assert_equal (a.Factors.Brand, g);
-%! assert_equal (a.Y, y);
-%! assert_equal (a.FactorNames, {'Brand'});
-%! assert_equal (a.SumOfSquaresType, 'two');
-%! assert_equal (! any (strcmp (methods ('anova'), 'predict'), 'all'), true);
+%! assert_equal (a.Response, y);
+%! assert_equal (isstring (a.FactorNames), true);
+%! assert_equal (cellstr (a.FactorNames), {"Brand"});
+%! assert_equal (isstring (a.SumOfSquaresType), true);
+%! assert_equal (char (a.SumOfSquaresType), "two");
+%! assert_equal (isstruct (a.Formula), true);
+%! assert_equal (! any (strcmp (methods ("anova"), "predict")), true);
 %! T = stats (a);
 %! M = groupmeans (a);
 %! V = varianceComponent (a);
@@ -2353,8 +3637,10 @@ endclassdef
 %! g = [1; 1; 1; 2; 2; 2; 3; 3; 3];
 %! a = anova (g, y, 'SumOfSquaresType', 'two');
 %! a.fit ();
-%! assert_equal (iscellstr (a.ExpandedFactorNames), true);
-%! assert_equal (! isempty (a.ExpandedFactorNames), true);
+%! assert_equal (isstring (a.ExpandedFactorNames), true);
+%! assert_equal (cellstr (a.ExpandedFactorNames), ...
+%!               {'(Intercept)'; '(Factor1==1)'; '(Factor1==2)'; ...
+%!                '(Factor1==3)'});
 
 ## groupmeans(): confidence bounds bracket the group means
 %!test
@@ -2384,6 +3670,53 @@ endclassdef
 %! a = anova (g, y, 'Weights', w);
 %! a.fit ();
 %! assert_equal (a.FittedValues + a.Residuals.Raw, y, 1e-9);
+
+## boxchart(): returns graphics handles in the requested axes
+%!test
+%! hfig = figure ("visible", "off");
+%! unwind_protect
+%!   ax = axes ("parent", hfig);
+%!   a = anova ([1;1;1;2;2;2], [1;2;3;4;5;6], ...
+%!              "SumOfSquaresType", "two");
+%!   h = boxchart (a, ax);
+%!   assert_equal (all (ishghandle (h)), true);
+%!   assert_equal (all (arrayfun (@(x) ancestor (x, "axes") == ax, h)), true);
+%! unwind_protect_cleanup
+%!   close (hfig);
+%! end_unwind_protect
+
+## plotComparisons(): plots adjusted means in the requested figure
+%!test
+%! hfig = figure ("visible", "off");
+%! unwind_protect
+%!   ax = axes ("parent", hfig);
+%!   a = anova ([1;1;1;2;2;2;3;3;3], (1:9)', ...
+%!              "SumOfSquaresType", "two");
+%!   h = plotComparisons (a, ax);
+%!   assert_equal (h, hfig);
+%!   assert_equal (numel (findall (ax, "type", "line")) >= 6, true);
+%! unwind_protect_cleanup
+%!   close (hfig);
+%! end_unwind_protect
+
+## plotComparisons(): Dunn-Sidak intervals are wider than unadjusted LSD
+%!test
+%! hfig = figure ("visible", "off");
+%! unwind_protect
+%!   ax1 = subplot (1, 2, 1, "parent", hfig);
+%!   ax2 = subplot (1, 2, 2, "parent", hfig);
+%!   a = anova (kron ((1:4)', ones (3, 1)), (1:12)', ...
+%!              "SumOfSquaresType", "two");
+%!   plotComparisons (a, ax1, "CriticalValueType", "lsd");
+%!   plotComparisons (a, ax2, "CriticalValueType", "dunn-sidak");
+%!   lsd = findobj (ax1, "type", "line", "linestyle", "-");
+%!   sidak = findobj (ax2, "type", "line", "linestyle", "-");
+%!   lsd_width = diff (get (lsd(1), "xdata"));
+%!   sidak_width = diff (get (sidak(1), "xdata"));
+%!   assert_equal (sidak_width > lsd_width, true);
+%! unwind_protect_cleanup
+%!   close (hfig);
+%! end_unwind_protect
 
 ## --- Week 5: diagnostic plots ------------------------------------------
 
@@ -2478,7 +3811,8 @@ endclassdef
 %!error <anova: Reps must be a positive integer scalar.> ...
 %! anova (magic (4), [], 'reps', 1.5)
 %!error <anova: ModelSpecification must be> ...
-%! anova ([1;1;2;2], [1;2;3;4], 'ModelSpecification', 'quadratic')
+%!  anova ([1;1;2;2], [1;2;3;4], 'ModelSpecification', 'cubic')
+
 %!error <anova: terms matrix must have one column per factor.> ...
 %! anova ([1;1;2;2], [1;2;3;4], 'Model', [1 0])
 %!error <anova: GROUP must match the number of observations.> ...
@@ -2625,7 +3959,7 @@ endclassdef
 %!               {'Factor1'; 'Factor2'; 'Factor1:Factor2'; 'Error'; 'Total'});
 %! assert_equal (__anova_values__ (component), ...
 %!               __anova_values__ (expected), 1e-10);
-%! assert_equal (a.SumOfSquaresType, 'three');
+%! assert_equal (char (a.SumOfSquaresType), 'three');
 %! assert_equal (istable (stats (a)), true);
 
 %!test
@@ -2718,6 +4052,21 @@ endclassdef
 %!     case 13
 %!       a = anova (g, y, 'Weights', v .^ -1);
 %!   endswitch
+%!   switch (k)
+%!     case 2
+%!       [~, ATAB, STATS] = anovan (score(:), ...
+%!           {treatment(:), subject(:)}, 'model', 'full', 'sstype', 2, ...
+%!           'varnames', {'treatment', 'subject'}, 'display', 'off');
+%!     case 4
+%!       [~, ATAB, STATS] = anovan (words(:), ...
+%!           {seconds(:), subject(:)}, 'model', 'full', 'sstype', 2, ...
+%!           'varnames', {'seconds', 'subject'}, 'display', 'off');
+%!     case 9
+%!       [~, ATAB, STATS] = anovan (measurement / 10, ...
+%!           {strain, treatment, block}, 'model', 'full', 'sstype', 2, ...
+%!           'varnames', {'strain', 'treatment', 'block'}, ...
+%!           'display', 'off');
+%!   endswitch
 %!   actual = stats (a);
 %!   actual_sources = actual.Properties.RowNames;
 %!   expected_sources = regexprep (ATAB(2:end, 1), "'$", "");
@@ -2727,24 +4076,329 @@ endclassdef
 %!     actual_sources{1} = expected_sources{1};
 %!   endif
 %!   assert_equal (actual_sources, expected_sources);
-%!   assert_equal (__anova_values__ (actual), ...
-%!                 __anova_values__ (ATAB), 1e-8);
+%!   actual_values = __anova_values__ (actual);
+%!   expected_values = __anova_values__ (ATAB);
+%!   if (any (k == [2, 4, 9]))
+%!     assert_equal (actual_values(:, 1:3), expected_values(:, 1:3), 1e-8);
+%!   else
+%!     assert_equal (actual_values, expected_values, 1e-8);
+%!   endif
 %!   if (! any (k == [1, 3, 12]))
-%!     assert_equal (a.Residuals, STATS.resid, 1e-8);
+%!     if (k == 13)
+%!       expected_residuals = STATS.Y - full (STATS.X) * STATS.coeffs(:, 1);
+%!     else
+%!       expected_residuals = STATS.resid;
+%!     endif
+%!     assert_equal (a.Residuals.Raw, expected_residuals, 1e-8);
 %!     assert_equal (size (a.DesignMatrix), size (STATS.X));
 %!   endif
 %! endfor
 
-%!error <anova: RandomFactors must contain positive integer indices.> ...
-%! anova ([1;1;2;2], [1;2;3;4], 'RandomFactors', 0)
-%!error <anova: RandomFactors indices exceed the number of factors.> ...
-%! anova ([1;1;2;2], [1;2;3;4], 'RandomFactors', 2)
-%!error <anova.stats: type must be a character vector.> ...
-%! stats (anova ([1;1;1;2;2;2;3;3;3], (1:9)'), 5)
-%!error <anova.groupmeans: factors are required for group means.> ...
-%! groupmeans (anova ([1;2;3;4;5;6]))
-%!error <anova.varianceComponent: random factors are not implemented.> ...
-%! varianceComponent (anova ([1;1;1;2;2;2;3;3;3], (1:9)', 'RandomFactors', 1))
+## MATLAB-compatible table constructors and public result schemas.
+%!test
+%! dose = [1; 1; 2; 2; 1; 2];
+%! site = {'A'; 'B'; 'A'; 'B'; 'A'; 'B'};
+%! yield = [1; 2; 4; 5; 2; 6];
+%! tbl = table (dose, site, yield, ...
+%!              'VariableNames', {'Dose', 'Site', 'Yield'});
+%! a = anova (tbl, 'Yield');
+%! assert_equal (cellstr (a.FactorNames), {'Dose', 'Site'});
+%! assert_equal (a.ResponseName, 'Yield');
+%! assert_equal (istable (a.Factors), true);
+%! assert_equal (a.Factors.Properties.VariableNames, {'Dose', 'Site'});
+%! assert_equal (a.Y, yield);
+%! T = stats (a);
+%! direct = stats (anova ({dose, site}, yield, ...
+%!                        'FactorNames', {'Dose', 'Site'}));
+%! assert_equal (__anova_values__ (T), __anova_values__ (direct), 1e-12);
+
+%!test
+%! dose = [1; 1; 2; 2; 1; 2];
+%! site = {'A'; 'B'; 'A'; 'B'; 'A'; 'B'};
+%! yield = [1; 2; 4; 5; 2; 6];
+%! tbl = table (dose, site, yield, ...
+%!              'VariableNames', {'Dose', 'Site', 'Yield'});
+%! a = anova (tbl, 'Yield ~ Dose + Site + Dose:Site');
+%! T = stats (a);
+%! direct = stats (anova ({dose, site}, yield, ...
+%!                        'FactorNames', {'Dose', 'Site'}, ...
+%!                        'ModelSpecification', 'full'));
+%! assert_equal (char (a.Formula.Text), ...
+%!               'Yield ~ Dose + Site + Dose:Site');
+%! assert_equal (a.ModelSpecification, char (a.Formula.Text));
+%! assert_equal (__anova_values__ (T), __anova_values__ (direct), 1e-12);
+
+%!test
+%! dose = [1; 1; 2; 2];
+%! site = [1; 2; 1; 2];
+%! y = [1; 2; 4; 5];
+%! tbl = table (dose, site, 'VariableNames', {'Dose', 'Site'});
+%! a = anova (tbl, y, 'FactorNames', {'Site'});
+%! assert_equal (cellstr (a.FactorNames), {'Site'});
+%! assert_equal (a.Factors.Site, site);
+%! assert_equal (stats (a).DF, [1; 2; 3]);
+
+%!test
+%! g1 = [1; 1; 1; 1; 2; 2; 2; 2];
+%! g2 = [1; 1; 2; 2; 1; 1; 2; 2];
+%! y = (1:8)';
+%! a = anova ({g1, g2}, y, 'FactorNames', {'A', 'B'}, ...
+%!            'CategoricalFactors', [true, false], 'RandomFactors', 'A');
+%! assert_equal (a.CategoricalFactors, 1);
+%! assert_equal (a.RandomFactors, 1);
+%! b = anova ({g1, g2}, y, 'FactorNames', {'A', 'B'}, ...
+%!            'CategoricalFactors', {'A', 'B'}, 'RandomFactors', 'all');
+%! assert_equal (b.CategoricalFactors, [1, 2]);
+%! assert_equal (b.RandomFactors, [1, 2]);
+
+%!test
+%! y = [1; 2; 3; 4; 5; 6];
+%! g = [1; 1; 1; 2; 2; 2];
+%! a = anova (g, y, 'SumOfSquaresType', 'two');
+%! stats (a);
+%! assert_equal (isvector (a.Coefficients), true);
+%! assert_equal (isstring (a.ExpandedFactorNames), true);
+%! assert_equal (istable (a.Residuals), true);
+%! assert_equal (a.Residuals.Properties.VariableNames, {'Raw', 'Pearson'});
+%! assert_equal (a.Residuals.Pearson, ...
+%!               a.Residuals.Raw / sqrt (a.Metrics.MSE), 1e-12);
+%! assert_equal (a.Metrics.Properties.VariableNames, ...
+%!               {'MSE', 'RMSE', 'SSE', 'SSR', 'SST', ...
+%!                'RSquared', 'AdjustedRSquared'});
+%! assert_equal (a.Metrics.SST, a.Metrics.SSE + a.Metrics.SSR, 1e-12);
+%! assert_equal (a.Coefficients, [3.5; -1.5; 1.5], 1e-12);
+%! assert_equal (cellstr (a.ExpandedFactorNames), ...
+%!               {'(Intercept)'; '(Factor1==1)'; '(Factor1==2)'});
+
+%!test
+%! y = [1; 2; 3; 4; 5; 6; 10; 11; 12];
+%! g = [1; 1; 1; 2; 2; 2; 3; 3; 3];
+%! a = anova (g, y);
+%! m = multcompare (a);
+%! assert_equal (istable (m), true);
+%! assert_equal (m.Properties.VariableNames, ...
+%!               {'Group1', 'Group2', 'MeanDifference', ...
+%!                'MeanDifferenceLower', 'MeanDifferenceUpper', 'pValue'});
+%! assert_equal (m.MeanDifference, [-3; -9; -6], 1e-12);
+%! v = varianceComponent (a);
+%! assert_equal (v.Properties.VariableNames, ...
+%!               {'VarianceComponent', 'VarianceComponentLower', ...
+%!                'VarianceComponentUpper'});
+%! assert_equal (v.Properties.RowNames, {'Error'});
+%! one_group = multcompare (anova (ones (4, 1), (1:4)'));
+%! assert_equal (istable (one_group), true);
+%! assert_equal (size (one_group), [0, 6]);
+
+%!test
+%! g1 = [1; 1; 1; 1; 2; 2; 2; 2];
+%! g2 = {'A'; 'A'; 'B'; 'B'; 'A'; 'A'; 'B'; 'B'};
+%! y = [1; 2; 3; 4; 5; 6; 8; 9];
+%! a = anova ({g1, g2}, y, 'FactorNames', {'Dose', 'Site'}, ...
+%!            'ModelSpecification', 'full');
+%! m = multcompare (a, {'Dose', 'Site'}, ...
+%!                  'CriticalValueType', 'bonferroni');
+%! assert_equal (istable (m.Group1), true);
+%! assert_equal (istable (m.Group2), true);
+%! assert_equal (m.Group1.Properties.VariableNames, {'Dose', 'Site'});
+%! assert_equal (rows (m), 6);
+
+%!test
+%! g1 = {"x, y"; "x, y"; "x, y"; "x, y"; "z=1"; "z=1"; "z=1"; "z=1"};
+%! g2 = {"a=1"; "a=1"; "b,2"; "b,2"; "a=1"; "a=1"; "b,2"; "b,2"};
+%! y = (1:8)';
+%! a = anova ({g1, g2}, y, "FactorNames", {"Dose", "Site"}, ...
+%!            "ModelSpecification", "full");
+%! m = multcompare (a, {"Dose", "Site"});
+%! values = [m.Group1.Dose; m.Group2.Dose; m.Group1.Site; m.Group2.Site];
+%! assert_equal (any (strcmp (values, "x, y")), true);
+%! assert_equal (any (strcmp (values, "z=1")), true);
+%! assert_equal (any (strcmp (values, "a=1")), true);
+%! assert_equal (any (strcmp (values, "b,2")), true);
+
+%!test
+%! g1 = [1; 1; 1; 1; 2; 2; 2; 2];
+%! g2 = [1; 1; 2; 2; 1; 1; 2; 2];
+%! y = (1:8)';
+%! a = anova ({g1, g2}, y, 'FactorNames', {'A', 'B'}, ...
+%!            'ResponseName', 'R', ...
+%!            'ModelSpecification', 'R ~ A + B + A:B');
+%! assert_equal (char (a.Formula.Text), 'R ~ A + B + A:B');
+%! assert_equal (stats (a).Properties.RowNames, ...
+%!               {'A'; 'B'; 'A:B'; 'Error'; 'Total'});
+%! b = anova ({g1, g2}, y, 'FactorNames', {'A', 'B'}, ...
+%!            'ModelSpecification', 3);
+%! assert_equal (b.ModelSpecification, 3);
+%! assert_equal (char (b.Formula.Text), 'Y ~ 1 + A + B + A:B');
+%! assert_equal (__anova_values__ (stats (a)), ...
+%!               __anova_values__ (stats (b)), 1e-12);
+
+%!test
+%! tbl = table ([1; 1; 2; 2], [1; 2; 3; 4], ...
+%!              'VariableNames', {'Group', 'Yield'});
+%! a = anova (tbl, 'Yield ~ Group', 'FactorNames', {'Yield'}, ...
+%!            'ResponseName', 'Ignored', 'ModelSpecification', 'full');
+%! assert_equal (cellstr (a.FactorNames), {'Group'});
+%! assert_equal (a.ResponseName, 'Yield');
+%! assert_equal (a.ModelSpecification, 'Yield ~ Group');
+
+%!test
+%! a = anova ([1; 1; 2; 2], [1; NaN; 3; 4]);
+%! stats (a);
+%! assert_equal (a.NumObservations, 3);
+%! assert_equal (a.Y, [1; 3; 4]);
+%! assert_equal (height (a.Factors), 3);
+%! assert_equal (height (a.Residuals), 3);
+
+## Random-factor variance components match MATLAB's documented carsmall example.
+%!test
+%! load carsmall
+%! a = anova ({Origin, Model_Year}, MPG, "RandomFactors", [1, 2], ...
+%!            "FactorNames", {"Origin", "Year"});
+%! v = varianceComponent (a);
+%! assert_equal (v.Properties.RowNames, {"Origin"; "Year"; "Error"});
+%! assert_equal (v.VarianceComponent, [21.337; 44.031; 20.198], 5e-3);
+%! assert_equal (v.VarianceComponentLower, [6.1257; 11.176; 15.298], 5e-3);
+%! assert_equal (v.VarianceComponentUpper, [139.94; 1765.7; 27.909], 5e-1);
+
+## Interactions containing a random factor remain in the model and provide
+## the denominator for fixed-effect tests.
+%!test
+%! A = kron ([1; 2], ones (12, 1));
+%! B = repmat (kron ([1; 2; 3], ones (4, 1)), 2, 1);
+%! y = 10 + 2 * (A == 2) + ...
+%!     [0;1;-1;0; 1;0;-1;0; -1;0;1;0; 0;1;0;-1; 2;1;0;1; -1;0;1;0];
+%! a = anova ({A, B}, y, "FactorNames", {"A", "B"}, ...
+%!            "ModelSpecification", "full", "RandomFactors", 2);
+%! [s, ems] = stats (a);
+%! assert_equal (s.Properties.RowNames, {"A"; "B"; "A:B"; "Error"; "Total"});
+%! assert_equal (s.F(1:3), [49; 1; 1], 1e-12);
+%! assert_equal (cellstr (ems.Type), {"fixed"; "random"; "random"; "random"});
+%! assert_equal (cellstr (ems.FDenominator), ...
+%!               {"MS(A:B)"; "MS(A:B)"; "MS(Error)"; ""});
+%! v = varianceComponent (a);
+%! assert_equal (v.Properties.RowNames, {"B"; "A:B"; "Error"});
+%! assert_equal (v.VarianceComponent(1) < 0, true);
+
+## Named polynomial models preserve MATLAB's term definitions.
+%!test
+%! x = (-2:2)';
+%! y = 2 + 3 * x + 4 * x .^ 2;
+%! a = anova (x, y, "CategoricalFactors", [], ...
+%!            "ModelSpecification", "purequadratic", ...
+%!            "FactorNames", {"x"});
+%! s = stats (a);
+%! assert_equal (a.Stats.terms, [1; 2]);
+%! assert_equal (s.Properties.RowNames, {"x"; "x^2"; "Error"; "Total"});
+%! assert_equal (a.FittedValues, y, 1e-12);
+
+## Hierarchical sums preserve polynomial power containment.
+%!test
+%! x = [0; 1; 2; 4; 7; 8; 10; 15];
+%! y = [1; 2; 3; 6; 12; 15; 21; 40];
+%! a = anova (x, y, "CategoricalFactors", [], ...
+%!            "ModelSpecification", [1; 2], ...
+%!            "SumOfSquaresType", "hierarchical");
+%! s = stats (a);
+%! assert_equal (char (a.SumOfSquaresType), "hierarchical");
+%! assert_equal (a.SSType, "h");
+%! assert_equal (s.SumOfSquares(1:2), ...
+%!               [1149.540669856459; 60.32250042332054], 1e-10);
+
+## Accepted aliases are canonicalized in the public property.
+%!test
+%! a = anova ([1; 1; 2; 2], (1:4)', "SumOfSquaresType", "typeii");
+%! assert_equal (char (a.SumOfSquaresType), "two");
+
+%!test
+%! [x1, x2] = ndgrid ((-2:2)', (-1:1)');
+%! x1 = x1(:);
+%! x2 = x2(:);
+%! y = 1 + 2*x1 + 3*x2 + 4*x1.*x2 + 5*x1.^2 + 6*x2.^2;
+%! a = anova ({x1, x2}, y, "CategoricalFactors", [], ...
+%!            "ModelSpecification", "quadratic");
+%! stats (a);
+%! assert_equal (a.Stats.terms, [1 0; 0 1; 1 1; 2 0; 0 2]);
+%! assert_equal (a.FittedValues, y, 1e-10);
+
+%!test
+%! [x1, x2] = ndgrid ([-1; 1], (-2:2)');
+%! x1 = x1(:);
+%! x2 = x2(:);
+%! y = x1 + x2.^2 + x2.^3 + x1.*x2 + x1.*x2.^2;
+%! a = anova ({x1, x2}, y, "CategoricalFactors", [], ...
+%!            "ModelSpecification", "poly13");
+%! stats (a);
+%! assert_equal (a.Stats.terms, [1 0; 0 1; 0 2; 0 3; 1 1; 1 2]);
+
+%!test
+%! x = (-2:2)';
+%! tbl = table (x, 2 + 3*x + 4*x.^2, "VariableNames", {"x", "y"});
+%! a = anova (tbl, "y ~ x^2", "CategoricalFactors", []);
+%! stats (a);
+%! assert_equal (a.Stats.terms, [1; 2]);
+%! assert_equal (a.FittedValues, tbl.y, 1e-12);
+
+## Nested factors use separate within-parent contrasts.
+%!test
+%! A = kron ([1; 2], ones (6, 1));
+%! B = repmat (kron ([1; 2], ones (3, 1)), 2, 1);
+%! y = 10*A + 2*B + repmat ([-1; 0; 1], 4, 1);
+%! tbl = table (A, B, y, "VariableNames", {"A", "B", "Y"});
+%! a = anova (tbl, "Y ~ A + B(A)");
+%! s = stats (a);
+%! assert_equal (a.Stats.terms, [1 0; 0 1]);
+%! assert_equal (a.Stats.vnested, logical ([0 0; 1 0]));
+%! assert_equal (s.Properties.RowNames, {"A"; "B(A)"; "Error"; "Total"});
+%! assert_equal (s.DF, [1; 2; 8; 11]);
+
+%!test
+%! [A, C, B, R] = ndgrid ([1; 2], [1; 2], [1; 2], [1; 2]);
+%! A = A(:); C = C(:); B = B(:); R = R(:);
+%! y = A + 2*C + 3*B + 0.1*R;
+%! tbl = table (A, B, C, y, "VariableNames", {"A", "B", "C", "Y"});
+%! a = anova (tbl, "Y ~ A*C + B(A,C)");
+%! s = stats (a);
+%! assert_equal (a.Stats.vnested, logical ([0 0 0; 1 0 1; 0 0 0]));
+%! assert_equal (s.Properties.RowNames, ...
+%!               {"A"; "C"; "A:C"; "B(A,C)"; "Error"; "Total"});
+%! assert_equal (s.DF(4), 4);
+
+## Unbalanced NaN cleanup preserves the anovan fallback results.
+%!test
+%! x = [1, 5; 2, 6; 3, 7; NaN, 8];
+%! warning ("off", "all", "local");
+%! a = anova (x, [], "Reps", 2, "ModelSpecification", "interactions");
+%! stats (a);
+%! assert_equal (a.Stats.source, "anovan");
+%! assert_equal (a.NumObservations, 7);
+%! assert_equal (height (a.Residuals), 7);
+
+## Numeric replicated models bypass anova2 when it cannot represent the terms.
+%!test
+%! x = [1, 5; 2, 6; 3, 7; 4, 8];
+%! a = anova (x, [], "Reps", 2, ...
+%!            "ModelSpecification", [1 0; 0 1], ...
+%!            "FactorNames", {"A", "B"});
+%! s = stats (a);
+%! assert_equal (s.Properties.RowNames, {"A"; "B"; "Error"; "Total"});
+
+## Raw residuals are unweighted observation-minus-fit differences.
+%!test
+%! g = [1; 1; 2; 2; 3; 3];
+%! y = [1; 3; 4; 8; 9; 15];
+%! a = anova (g, y, "Weights", [1; 2; 1; 3; 1; 4]);
+%! stats (a);
+%! assert_equal (a.Residuals.Raw, a.Y - a.FittedValues, 1e-12);
+
+%!error <polynomial powers require continuous> ...
+%! anova ([1; 1; 2; 2], (1:4)', "ModelSpecification", "purequadratic")
+
+%!error <anova: RandomFactors must contain valid factor indices.> ...
+%!  anova ([1;1;2;2], [1;2;3;4], "RandomFactors", 0)
+
+%!error <anova: RandomFactors must contain valid factor indices.> ...
+%!  anova ([1;1;2;2], [1;2;3;4], "RandomFactors", 2)
+
 %!error <diagnostic plots require>
 %! popcorn = [5.5, 4.5, 3.5; 5.5, 4.5, 4.0; 6.0, 4.0, 3.0; ...
 %!            6.5, 5.0, 4.0; 7.0, 5.5, 5.0; 7.0, 5.0, 4.5];

--- a/inst/Hypothesis_Testing/anova.m
+++ b/inst/Hypothesis_Testing/anova.m
@@ -34,7 +34,7 @@ classdef anova
   ## @code{fit} internally when necessary, so users may construct an object and
   ## immediately call inspection or post-hoc methods.
   ##
-  ## @seealso{anova1, anova2, anovan, multcompare, fitlm, LinearModel}
+  ## @seealso{anova1, anova2, anovan, multcompare}
   ## @end deftp
 
   properties (GetAccess = public, SetAccess = private)
@@ -227,7 +227,6 @@ classdef anova
     nFactors_   = 0;
     backend_    = '';                       ## 'anova1' | 'anova2' | 'anovan'
     reps_       = [];                       ## replicate count for anova2 backend
-    sourceModel_ = [];                       ## LinearModel object, when supplied
     continuousSpecified_ = false;
     coefficientStats_ = [];
     rawResiduals_ = [];
@@ -246,7 +245,6 @@ classdef anova
     ## @var{responseVarName})
     ## @deftypefnx {anova} {@var{obj} =} anova (@var{tbl}, @var{formula})
     ## @deftypefnx {anova} {@var{obj} =} anova (@dots{}, @var{name}, @var{value})
-    ## @deftypefnx {anova} {@var{obj} =} anova (@var{mdl})
     ##
     ## Create an object-oriented analysis of variance model.
     ##
@@ -269,9 +267,6 @@ classdef anova
     ## Passing @qcode{'Reps'} selects the balanced two-way @code{anova2}
     ## backend when @var{Y} is a non-vector matrix.
     ##
-    ## @var{mdl} may be a @code{LinearModel} object, in which case the ANOVA
-    ## object is populated from the fitted linear model's public properties.
-    ##
     ## @end deftypefn
     function obj = anova (factors, Y, varargin)
 
@@ -285,15 +280,6 @@ classdef anova
       table_factors = [];
       formula_input = "";
       response_locked = false;
-
-      if (isa (factors, 'LinearModel'))
-        lm_args = varargin;
-        if (! isempty (Y))
-          lm_args = [{Y}, lm_args];
-        endif
-        obj = obj.initLinearModel_ (factors, lm_args{:});
-        return;
-      endif
 
       if (isa (factors, "table"))
         if (nargin < 2)
@@ -748,9 +734,6 @@ classdef anova
     ## @end deftypefn
     function m = multcompare (obj, varargin)
       obj.ensureFit_ ();
-      if (strcmp (obj.backend_, 'linearmodel'))
-        error ("anova.multcompare: LinearModel-backed ANOVA is not supported.");
-      endif
       if (isempty (fieldnames (obj.Stats)))
         error ("anova.multcompare: model has no stats to compare.");
       endif
@@ -789,10 +772,9 @@ classdef anova
     ##
     ## The method creates a four-panel figure containing a Normal Q-Q plot, a
     ## Spread-Location plot, a Residual-Leverage plot, and a Cook's distance
-    ## plot.  Diagnostic plots require an @code{anovan}-backed fit or a
-    ## @code{LinearModel}-backed object because the fast @code{anova1} and
-    ## @code{anova2} backends do not expose residuals and design-matrix
-    ## diagnostics.
+    ## plot.  Diagnostic plots require an @code{anovan}-backed fit because the
+    ## fast @code{anova1} and @code{anova2} backends do not expose residuals
+    ## and design-matrix diagnostics.
     ##
     ## Supported name-value arguments are @qcode{'FigureName'} and
     ## @qcode{'Visible'}.
@@ -800,14 +782,6 @@ classdef anova
     ## @end deftypefn
     function h = plotDiagnostics (obj, varargin)
       obj.ensureFit_ ();
-      if (! isempty (obj.sourceModel_))
-        mdl = obj.sourceModel_;
-        h = obj.plotDiagnostics_ (mdl.Residuals.Raw, mdl.Fitted, ...
-                                  mdl.Diagnostics.Leverage, ...
-                                  mdl.Diagnostics.CooksDistance, ...
-                                  mdl.DFE, varargin{:});
-        return;
-      endif
       if (isempty (obj.rawResiduals_) || isempty (obj.FittedValues) ...
           || isempty (obj.DesignMatrix))
         error (strcat ("anova.plotDiagnostics: diagnostic plots require", ...
@@ -832,22 +806,11 @@ classdef anova
     ##
     ## With no @var{Xnew}, return fitted values for the training data.  For an
     ## @code{anovan}-backed object, @var{Xnew} must be a numeric design matrix
-    ## with one column per coefficient.  For a @code{LinearModel}-backed
-    ## object, prediction is delegated to @code{predict} on the stored
-    ## @code{LinearModel}, so that table input and categorical encoding remain
-    ## owned by @code{LinearModel}.
+    ## with one column per coefficient.
     ##
     ## @end deftypefn
     function ypred = predict (obj, Xnew, varargin)
       obj.ensureFit_ ();
-      if (! isempty (obj.sourceModel_))
-        if (nargin < 2)
-          ypred = predict (obj.sourceModel_);
-        else
-          ypred = predict (obj.sourceModel_, Xnew, varargin{:});
-        endif
-        return;
-      endif
       if (nargin < 2 || isempty (Xnew))
         ypred = obj.FittedValues;
         return;
@@ -874,18 +837,12 @@ classdef anova
     ##
     ## The returned structure contains fields @code{Source},
     ## @code{EtaSquared}, @code{PartialEtaSquared}, and @code{OmegaSquared}.
-    ## For @code{anovan}-backed fits, values are derived from the fitted ANOVA
-    ## table.  For @code{LinearModel}-backed fits, model-level values are
-    ## computed from @code{SSR}, @code{SSE}, @code{SST}, and @code{MSE}.
+    ## Values are derived from the fitted ANOVA table.
     ##
     ## @end deftypefn
     function es = getEffectSizes (obj)
       obj.ensureFit_ ();
-      if (strcmp (obj.backend_, 'linearmodel'))
-        es = obj.linearModelEffectSizes_ ();
-      else
-        es = obj.effectSizesFromAtab_ ();
-      endif
+      es = obj.effectSizesFromAtab_ ();
     endfunction
 
   endmethods
@@ -1855,8 +1812,7 @@ classdef anova
     endfunction
 
     ## Build the public Residuals table (Raw and Pearson) from a raw residual
-    ## vector.  Pearson residuals scale the raw residuals by the RMSE, matching
-    ## the LinearModel definition.
+    ## vector.  Pearson residuals scale the raw residuals by the RMSE.
     function tbl = residualsTable_ (obj, raw)
       raw = raw(:);
       pearson = raw ./ sqrt (max (obj.MSE, eps));
@@ -1930,11 +1886,6 @@ classdef anova
 
     function ems = expectedMeanSquares_ (obj, sstype)
       obj.ensureFit_ ();
-      if (strcmp (obj.backend_, "linearmodel"))
-        error (strcat ("anova.stats: expected mean squares are unavailable", ...
-                       " for LinearModel input."));
-      endif
-
       [atab, stats_] = obj.componentFit_ (sstype);
       sources = obj.publicSourceNames_ (atab(2:end-1, 1));
       nterms = numel (sources) - 1;
@@ -2260,65 +2211,6 @@ classdef anova
       endif
     endfunction
 
-    function obj = initLinearModel_ (obj, mdl, varargin)
-      if (mod (numel (varargin), 2) != 0)
-        error ("anova: name-value pairs must come in pairs.");
-      endif
-      for idx = 1:2:numel (varargin)
-        name = varargin{idx};
-        value = varargin{idx + 1};
-        if (! ischar (name))
-          error ("anova: parameter name must be a character vector.");
-        endif
-        switch (lower (name))
-          case 'alpha'
-            obj.Alpha = value;
-          case {'display', 'displayopt'}
-            obj.Display = value;
-          otherwise
-            error ("anova: parameter '%s' is not supported.", name);
-        endswitch
-      endfor
-      obj.validateSpec_ ();
-
-      obj.sourceModel_ = mdl;
-      obj.backend_ = 'linearmodel';
-      obj.nFactors_ = mdl.NumPredictors;
-      obj.NumFactors = obj.nFactors_;
-      obj.ModelSpecification = mdl.Formula.Terms;
-      obj.ModelType = mdl.Formula.Terms;
-      obj.VarNames = cellstr (mdl.PredictorNames);
-      obj.FactorNames = string (obj.VarNames);
-      obj.SumOfSquaresType = string (obj.SumOfSquaresType);
-      obj.ResponseName = mdl.ResponseName;
-      obj.formulaTerms_ = mdl.Formula.Terms;
-      linear_predictor = char (mdl.Formula.LinearPredictor);
-      if (isempty (strfind (linear_predictor, "~")))
-        obj.formulaText_ = sprintf ("%s ~ %s", obj.ResponseName, ...
-                                    linear_predictor);
-      else
-        obj.formulaText_ = linear_predictor;
-      endif
-      obj.updateFormula_ ();
-      obj.Y = mdl.Variables{:, mdl.ResponseName};
-      obj.GROUP = mdl.Variables(:, mdl.PredictorNames);
-      obj.Factors = obj.GROUP;
-      obj.ExpandedFactorNames = mdl.CoefficientNames;
-      obj.NumObservations = numel (obj.Y);
-      obj.coefficientStats_ = obj.linearModelCoefficients_ (mdl);
-      obj.Coefficients = obj.coefficientStats_(:, 1);
-      obj.AnovaTable = obj.linearModelAtab_ (mdl);
-      obj.rawResiduals_ = mdl.Residuals.Raw;
-      obj.FittedValues = mdl.Fitted;
-      obj.DFE = mdl.DFE;
-      obj.MSE = mdl.MSE;
-      obj.Residuals = obj.residualTable_ (obj.rawResiduals_, obj.MSE);
-      obj.DesignMatrix = [];
-      obj.Stats = obj.linearModelStats_ (mdl);
-      obj.updatePublicResults_ ();
-      obj.fitted_ = true;
-      obj.dirty_ = false;
-    endfunction
 
     function validateSpec_ (obj)
       if (! ((isnumeric (obj.SSType) && isscalar (obj.SSType) ...
@@ -2504,8 +2396,6 @@ classdef anova
           obj = obj.fitAnova2_ ();
         case 'anovan'
           obj = obj.fitAnovan_ ();
-        case 'linearmodel'
-          ## Already populated from the supplied LinearModel object.
       endswitch
       obj = obj.updatePublicResults_ ();
       obj.fitted_ = true;
@@ -2593,9 +2483,6 @@ classdef anova
     endfunction
 
     function [atab, stats_] = componentFit_ (obj, sstype)
-      if (strcmp (obj.backend_, "linearmodel"))
-        error ("anova.stats: component type is unavailable for LinearModel input.");
-      endif
       if (strcmp (obj.backend_, "anova2"))
         obj.ensureFit_ ();
         atab = obj.AnovaTable;
@@ -3074,69 +2961,6 @@ classdef anova
       set (findall (gcf, '-property', 'FontSize'), 'FontSize', 7);
     endfunction
 
-    function coeffs = linearModelCoefficients_ (obj, mdl)
-      est = mdl.Coefficients.Estimate;
-      se = mdl.Coefficients.SE;
-      tstat = mdl.Coefficients.tStat;
-      pval = mdl.Coefficients.pValue;
-      crit = tinv (1 - obj.Alpha / 2, mdl.DFE);
-      coeffs = [est, se, est - crit * se, est + crit * se, tstat, pval];
-    endfunction
-
-    function atab = linearModelAtab_ (obj, mdl)
-      has_intercept = isa (mdl.Formula, 'LinearFormula') ...
-                      && mdl.Formula.HasIntercept;
-      intercept_df = 0;
-      if (has_intercept)
-        intercept_df = 1;
-      endif
-      df_model = mdl.NumEstimatedCoefficients - intercept_df;
-      df_model = max (df_model, 0);
-      if (df_model > 0)
-        ms_model = mdl.SSR / df_model;
-      else
-        ms_model = NaN;
-      endif
-      atab = {'Source', 'SS', 'df', 'MS', 'F', 'Prob>F'; ...
-              'Model', mdl.SSR, df_model, ms_model, ...
-              mdl.ModelFitVsNullModel.Fstat, mdl.ModelFitVsNullModel.Pvalue; ...
-              'Error', mdl.SSE, mdl.DFE, mdl.MSE, '', ''; ...
-              'Total', mdl.SST, mdl.NumObservations - intercept_df, ...
-              '', '', ''};
-    endfunction
-
-    function stats = linearModelStats_ (obj, mdl)
-      stats = struct ('source', 'linearmodel', ...
-                      'resid', mdl.Residuals.Raw, ...
-                      'coeffs', obj.Coefficients, ...
-                      'dfe', mdl.DFE, ...
-                      'mse', mdl.MSE, ...
-                      'vcov', mdl.CoefficientCovariance, ...
-                      'CooksD', mdl.Diagnostics.CooksDistance, ...
-                      'alpha', obj.Alpha, ...
-                      'varnames', {mdl.VariableNames}, ...
-                      'coeffnames', {mdl.CoefficientNames});
-    endfunction
-
-    function es = linearModelEffectSizes_ (obj)
-      mdl = obj.sourceModel_;
-      eta = mdl.SSR / max (mdl.SST, eps);
-      partial_eta = mdl.SSR / max (mdl.SSR + mdl.SSE, eps);
-      has_intercept = isa (mdl.Formula, 'LinearFormula') ...
-                      && mdl.Formula.HasIntercept;
-      intercept_df = 0;
-      if (has_intercept)
-        intercept_df = 1;
-      endif
-      df_model = max (mdl.NumEstimatedCoefficients - intercept_df, 0);
-      omega = (mdl.SSR - df_model * mdl.MSE) / max (mdl.SST + mdl.MSE, eps);
-      es = struct ();
-      es.Source = {'Model'};
-      es.EtaSquared = eta;
-      es.PartialEtaSquared = partial_eta;
-      es.OmegaSquared = omega;
-    endfunction
-
     function es = effectSizesFromAtab_ (obj)
       atab = obj.AnovaTable;
       if (isempty (atab))
@@ -3365,11 +3189,15 @@ endclassdef
 %! g2 = [1; 1; 2; 2; 1; 1; 2; 2];
 %! a = anova ({g1, g2}, y);
 %! assert_equal (a.NumFactors, 2);
+%! assert_equal (a.NumObservations, 7);
+%! assert_equal (a.Stats.source, 'anovan');
 
 ## Backend selection: weights force anovan
 %!test
 %! a = anova ([1;1;2;2;3;3], [1;2;3;4;5;6], 'Weights', ones (6, 1));
-%! assert_equal (isempty (stats (a)), false);
+%! assert_equal (a.Stats.source, 'anovan');
+%! assert_equal (stats (a).Properties.RowNames, ...
+%!               {'Factor1'; 'Error'; 'Total'});
 
 ## --- Week 2: fit delegation smoke tests --------------------------------
 
@@ -3379,10 +3207,10 @@ endclassdef
 %! g = [1; 1; 2; 2; 3; 3];
 %! a = anova (g, y);
 %! a.fit ();
-%! assert_equal (isempty (a.AnovaTable), false);
-%! assert_equal (class (a.Stats), 'struct');
-%! assert_equal (isempty (a.DFE), false);
-%! assert_equal (isempty (a.MSE), false);
+%! assert_equal (size (a.AnovaTable), [4, 6]);
+%! assert_equal (a.Stats.source, 'anova1');
+%! assert_equal (a.DFE, 3);
+%! assert_equal (a.MSE, 0.5, 1e-12);
 
 ## fit_(): two-way balanced fixture (anova2 backend, popcorn data)
 %!test
@@ -3391,9 +3219,9 @@ endclassdef
 %! a = anova (popcorn, [], 'reps', 3);
 %! assert_equal (! isempty (strfind (evalc ('disp (a)'), '2-way anova')), true);
 %! a.fit ();
-%! assert_equal (! isempty (a.AnovaTable), true);
-%! assert_equal (isfield (a.Stats, 'sigmasq'), true);
-%! assert_equal (a.MSE, a.Stats.sigmasq);
+%! assert_equal (size (a.AnovaTable), [5, 6]);
+%! assert_equal (a.MSE, 0.125, 1e-12);
+%! assert_equal (a.Stats.sigmasq, 0.125, 1e-12);
 
 ## fit_(): N-way fixture (anovan backend, three factors)
 %!test
@@ -3404,11 +3232,11 @@ endclassdef
 %! a = anova ({g1, g2, g3}, y);
 %! assert_equal (a.NumFactors, 3);
 %! a.fit ();
-%! assert_equal (! isempty (a.AnovaTable), true);
-%! assert_equal (! isempty (a.Coefficients), true);
-%! assert_equal (! isempty (a.Residuals), true);
-%! assert_equal (! isempty (a.DesignMatrix), true);
-%! assert_equal (rows (a.Residuals), numel (y));
+%! assert_equal (a.Stats.source, 'anovan');
+%! assert_equal (size (a.AnovaTable), [6, 7]);
+%! assert_equal (size (a.Coefficients), [7, 1]);
+%! assert_equal (size (a.Residuals), [24, 2]);
+%! assert_equal (size (a.DesignMatrix), [24, 4]);
 
 ## fit_(): FittedValues = DesignMatrix * Coefficients(:,1) for anovan
 %!test
@@ -3544,8 +3372,7 @@ endclassdef
 %! g = [1; 1; 1; 2; 2; 2; 3; 3; 3];
 %! a = anova (g, y, 'SumOfSquaresType', 'two');
 %! C = multcompare (a);
-%! assert_equal (! isempty (C), true);
-%! assert_equal (size (C, 1), 3);        ## 3 pairwise comparisons for 3 groups
+%! assert_equal (size (C), [3, 6]);
 %! assert_equal (C.Properties.VariableNames, ...
 %!               {'Group1', 'Group2', 'MeanDifference', ...
 %!                'MeanDifferenceLower', 'MeanDifferenceUpper', 'pValue'});
@@ -3556,14 +3383,13 @@ endclassdef
 %!            6.5, 5.0, 4.0; 7.0, 5.5, 5.0; 7.0, 5.0, 4.5];
 %! a = anova (popcorn, [], 'reps', 3);
 %! C = multcompare (a, 'Factor1');
-%! assert_equal (! isempty (C), true);
-%! assert_equal (width (C), 6);
+%! assert_equal (size (C), [3, 6]);
 
 ## multcompare(): runs after a fresh construction (triggers ensureFit_)
 %!test
 %! a = anova ([1;1;2;2;3;3], (1:6)', 'SumOfSquaresType', 'two');
 %! C = multcompare (a);
-%! assert_equal (! isempty (C), true);
+%! assert_equal (size (C), [3, 6]);
 
 ## MATLAB-compatible public methods and properties
 %!test
@@ -3657,7 +3483,7 @@ endclassdef
 %!   y = [1; 2; 3; 4; 5; 6; 10; 11; 12];
 %!   g = [1; 1; 1; 2; 2; 2; 3; 3; 3];
 %!   h = boxchart (anova (g, y));
-%!   assert_equal (! isempty (h), true);
+%!   assert_equal (all (ishghandle (h)), true);
 %! unwind_protect_cleanup
 %!   close (hf);
 %! end_unwind_protect
@@ -3735,7 +3561,7 @@ endclassdef
 %!   close (hf);
 %! end_unwind_protect
 
-## --- Week 6: predict / effect sizes / LinearModel bridge ----------------
+## --- Week 6: predict / effect sizes -------------------------------------
 
 ## predict(): no Xnew returns fitted values
 %!test
@@ -3761,33 +3587,6 @@ endclassdef
 %! assert_equal (iscell (es.Source), true);
 %! assert_equal (numel (es.EtaSquared), numel (es.Source));
 %! assert_equal (all (isfinite (es.PartialEtaSquared), 'all'), true);
-
-## anova(LinearModel): builds from Avanish's LinearModel surface
-%!test
-%! X = [1; 2; 3; 4; 5];
-%! y = [2; 4; 5; 4; 5];
-%! mdl = fitlm (X, y);
-%! a = anova (mdl);
-%! assert_equal (! isempty (strfind (evalc ('disp (a)'), 'anova')), true);
-%! assert_equal (! isempty (a.AnovaTable), true);
-%! assert_equal (predict (a), mdl.Fitted, 1e-9);
-%! es = getEffectSizes (a);
-%! assert_equal (es.Source, {'Model'});
-%! assert_equal (es.EtaSquared, mdl.SSR / mdl.SST, 1e-9);
-
-## anova(LinearModel): plotDiagnostics uses LinearModel diagnostics
-%!test
-%! X = [1; 2; 3; 4; 5];
-%! y = [2; 4; 5; 4; 5];
-%! mdl = fitlm (X, y);
-%! a = anova (mdl);
-%! h = plotDiagnostics (a, 'Visible', 'off');
-%! unwind_protect
-%!   assert_equal (all (ishghandle (h), 'all'), true);
-%!   assert_equal (numel (findall (h, 'type', 'axes')), 4);
-%! unwind_protect_cleanup
-%!   close (h);
-%! end_unwind_protect
 
 ## --- Input validation ---------------------------------------------------
 

--- a/inst/Hypothesis_Testing/anova.m
+++ b/inst/Hypothesis_Testing/anova.m
@@ -1924,25 +1924,27 @@ classdef anova
 endclassdef
 
 %!demo
-%! ## One-way ANOVA with a formatted summary
+%! ## Fit an ANOVA object and inspect component and summary statistics
 %! y = [1; 2; 3; 4; 5; 6; 10; 11; 12];
 %! g = [1; 1; 1; 2; 2; 2; 3; 3; 3];
-%! a = anova (g, y, 'SumOfSquaresType', 'two');
-%! summary (a);
+%! aov = anova (g, y, 'FactorNames', {'Treatment'});
+%! component = stats (aov)
+%! summary_table = stats (aov, 'summary')
 
 %!demo
-%! ## Post-hoc multiple comparisons
+%! ## Estimate group means and perform post-hoc comparisons
 %! y = [1; 2; 3; 4; 5; 6; 10; 11; 12];
 %! g = [1; 1; 1; 2; 2; 2; 3; 3; 3];
-%! a = anova (g, y, 'SumOfSquaresType', 'two');
-%! C = multcompare (a, 'display', 'off')
+%! aov = anova (g, y, 'SumOfSquaresType', 'two');
+%! means = groupmeans (aov)
+%! comparisons = multcompare (aov, 'display', 'off')
 
 %!demo
-%! ## Diagnostic plots for an anovan-backed fit
-%! y = [10; 12; 11; 14; 16; 15; 9; 8; 10];
+%! ## Plot multiple-comparison intervals
+%! y = [1; 2; 3; 4; 5; 6; 10; 11; 12];
 %! g = [1; 1; 1; 2; 2; 2; 3; 3; 3];
-%! a = anova (g, y, 'SumOfSquaresType', 'two');
-%! plotDiagnostics (a);
+%! aov = anova (g, y, 'SumOfSquaresType', 'two');
+%! plotComparisons (aov);
 
 ## --- BISTs ---------------------------------------------------------------
 

--- a/inst/Hypothesis_Testing/anova1.m
+++ b/inst/Hypothesis_Testing/anova1.m
@@ -461,7 +461,7 @@ endfunction
 %!test
 %! g = kron ((1:120)', ones (2, 1));
 %! [p, tbl, stats] = anova1 ((1:240)', g, 'off');
-%! assert (isfinite (p));
+%! assert_equal (isfinite (p), true);
 %! assert_equal (tbl{2, 3}, 119);
 %! assert_equal (tbl{3, 3}, 120);
 %! assert_equal (stats.n, 2 * ones (1, 120));

--- a/inst/Hypothesis_Testing/anova1.m
+++ b/inst/Hypothesis_Testing/anova1.m
@@ -155,14 +155,28 @@ function [p, anovatab, stats] = anova1 (x, group, displayopt, vartype)
   endif
 
   ## Convert group to indices and separate names first
-  [group_id, group_names] = grp2idx (group);
-  group_id = group_id(:);
+  if (isa (group, "categorical"))
+    group_id = double (group(:));
+    group_names = categories (group);
+  else
+    [group_id, group_names] = grp2idx (group);
+    group_id = group_id(:);
+  endif
   x = x(:);
 
   ## identify NaN values in x or missing/empty categories in the group and remove them.
   valid_data = ! isnan (x) & ! isnan (group_id);
   x = x(valid_data);
   group_id = group_id(valid_data);
+  groups = size (group_names, 1);
+  xs = accumarray (group_id, 1, [groups, 1], @sum, 0);
+  observed_groups = (xs > 0);
+  if (any (! observed_groups))
+    group_map = cumsum (observed_groups);
+    group_id = group_map(group_id);
+    group_names = group_names(observed_groups, :);
+    xs = xs(observed_groups);
+  endif
   named = 1;
 
   ## Center data to improve accuracy and keep uncentered data for plotting
@@ -173,7 +187,6 @@ function [p, anovatab, stats] = anova1 (x, group, displayopt, vartype)
 
   ## Get group size and mean for each group
   groups = size (group_names, 1);
-  xs = accumarray (group_id, 1, [groups, 1], @sum, 0);
   xsum = accumarray (group_id, xr, [groups, 1], @sum, 0);
   xm = xsum ./ xs;
   xdev = xr - xm(group_id);
@@ -203,7 +216,10 @@ function [p, anovatab, stats] = anova1 (x, group, displayopt, vartype)
       MSE = NaN;
   endif
   ## Calculate F statistic
-  if (SSE != 0)                     ## Regular Matrix case.
+  if (dfm <= 0 || dfe <= 0)         ## Insufficient degrees of freedom.
+    F = NaN;
+    p = NaN;
+  elseif (SSE != 0)                 ## Regular Matrix case.
     switch (lower (vartype))
       case 'equal'
         ## Assume equal variances (Fisher's One-way ANOVA)
@@ -405,6 +421,50 @@ endfunction
 %! g = [ones(10, 1); 2 * ones(10, 1)];
 %! [~, ~, stats] = anova1 (y, g, 'off', 'unequal');
 %! assert_equal (stats.vars, [55 / 6, 55 / 6], 1e-10);
+
+## Degenerate designs return an undefined test statistic.
+%!test
+%! [p, tbl] = anova1 ((1:5)', ones (5, 1), 'off');
+%! assert_equal (p, NaN);
+%! assert_equal (tbl{2, 3}, 0);
+%! [p, tbl] = anova1 (7, 1, 'off');
+%! assert_equal (p, NaN);
+%! assert_equal (tbl{3, 3}, 0);
+%! [p, tbl] = anova1 ([1; 2], [1; 2], 'off');
+%! assert_equal (p, NaN);
+%! assert_equal (tbl{3, 3}, 0);
+
+## Identical observations have no between-group variation.
+%!test
+%! [p, tbl] = anova1 (ones (6, 1), [1; 1; 1; 2; 2; 2], 'off');
+%! assert_equal (p, 1);
+%! assert_equal (tbl{2, 2}, 0);
+%! assert_equal (tbl{3, 2}, 0);
+
+## Unused categorical levels do not enter the fitted design.
+%!test
+%! y = (1:6)';
+%! g = categorical ([1; 1; 3; 3; 3; 1], [1, 2, 3]);
+%! [p, tbl, stats] = anova1 (y, g, 'off');
+%! [p_ref, tbl_ref] = anova1 (y, [1; 1; 2; 2; 2; 1], 'off');
+%! assert_equal (p, p_ref, 1e-12);
+%! assert_equal (tbl, tbl_ref);
+%! assert_equal (stats.n, [3, 3]);
+%! assert_equal (stats.gnames, {'1'; '3'});
+%! assert_equal (stats.means, [3, 4]);
+%! g = categorical ([3; 3; 1; 1], [3, 2, 1]);
+%! [~, ~, stats] = anova1 ((1:4)', g, 'off');
+%! assert_equal (stats.gnames, {'3'; '1'});
+%! assert_equal (stats.means, [1.5, 3.5]);
+
+## Many factor levels retain the expected degrees of freedom.
+%!test
+%! g = kron ((1:120)', ones (2, 1));
+%! [p, tbl, stats] = anova1 ((1:240)', g, 'off');
+%! assert (isfinite (p));
+%! assert_equal (tbl{2, 3}, 119);
+%! assert_equal (tbl{3, 3}, 120);
+%! assert_equal (stats.n, 2 * ones (1, 120));
 
 ## testing handling of missing values in both data and grouping variables
 ## using categorical array as a grouping variable

--- a/inst/Hypothesis_Testing/anova1.m
+++ b/inst/Hypothesis_Testing/anova1.m
@@ -175,9 +175,10 @@ function [p, anovatab, stats] = anova1 (x, group, displayopt, vartype)
   groups = size (group_names, 1);
   xs = accumarray (group_id, 1, [groups, 1], @sum, 0);
   xsum = accumarray (group_id, xr, [groups, 1], @sum, 0);
-  xsum2 = accumarray (group_id, xr .^ 2, [groups, 1], @sum, 0);
   xm = xsum ./ xs;
-  xv = (xsum2 - (xsum .^ 2) ./ xs) ./ max (xs - 1, 1);
+  xdev = xr - xm(group_id);
+  xss = accumarray (group_id, xdev .^ 2, [groups, 1], @sum, 0);
+  xv = xss ./ max (xs - 1, 1);
   xv(xs == 0) = NaN;
   xs = xs';
   xm = xm';
@@ -397,6 +398,13 @@ endfunction
 %! assert_equal (tbl{3,3}, 2, 0);
 %! assert_equal (tbl{4,3}, 3, 0);
 %! assert_equal (stats.n, [2, 2], 0);
+
+## Grouped variance remains stable when group means have large offsets.
+%!test
+%! y = [1e12 + (1:10), -1e12 + (1:10)](:);
+%! g = [ones(10, 1); 2 * ones(10, 1)];
+%! [~, ~, stats] = anova1 (y, g, 'off', 'unequal');
+%! assert_equal (stats.vars, [55 / 6, 55 / 6], 1e-10);
 
 ## testing handling of missing values in both data and grouping variables
 ## using categorical array as a grouping variable

--- a/inst/Hypothesis_Testing/anova1.m
+++ b/inst/Hypothesis_Testing/anova1.m
@@ -173,15 +173,15 @@ function [p, anovatab, stats] = anova1 (x, group, displayopt, vartype)
 
   ## Get group size and mean for each group
   groups = size (group_names, 1);
-  xs = zeros (1, groups);
-  xm = xs;
-  xv = xs;
-  for j = 1:groups
-    group_size = find (group_id == j);
-    xs(j) = length (group_size);
-    xm(j) = mean (xr(group_size));
-    xv(j) = var (xr(group_size), 0);
-  endfor
+  xs = accumarray (group_id, 1, [groups, 1], @sum, 0);
+  xsum = accumarray (group_id, xr, [groups, 1], @sum, 0);
+  xsum2 = accumarray (group_id, xr .^ 2, [groups, 1], @sum, 0);
+  xm = xsum ./ xs;
+  xv = (xsum2 - (xsum .^ 2) ./ xs) ./ max (xs - 1, 1);
+  xv(xs == 0) = NaN;
+  xs = xs';
+  xm = xm';
+  xv = xv';
 
   ## Calculate statistics
   lx = length (xr);                       ## Number of samples in groups

--- a/inst/Hypothesis_Testing/anova2.m
+++ b/inst/Hypothesis_Testing/anova2.m
@@ -161,12 +161,10 @@ function [p, anovatab, stats] = anova2 (x, reps, displayopt, model)
 
   ## Calculate Sum of Squares Error (Within)
   if (reps > 1)
-    SSE = 0;
-    for i = 1:FFGn
-      for j = 1:SFGn
-        SSE += sum ((x(RIdx(i,:),j) - mean (x(RIdx(i,:),j))) .^ 2);
-      endfor
-    endfor
+    xcells = reshape (x, reps, FFGn, SFGn);
+    xdev = bsxfun (@minus, xcells, mean (xcells, 1));
+    cell_sse = squeeze (sum (xdev .^ 2, 1));
+    SSE = sum (cell_sse.'(:));
   else
     SSE = SST - SSC - SSR;
   endif

--- a/inst/Hypothesis_Testing/anova2.m
+++ b/inst/Hypothesis_Testing/anova2.m
@@ -516,7 +516,7 @@ endfunction
 %! ## Unbalanced NaN removal follows MATLAB guidance and uses anovan.
 %! x = [1 NaN; 2 5; 3 6; 4 7; 8 8; 10 9];
 %! str = evalc ("[p, atab, stats] = anova2 (x, 3, 'off');");
-%! assert (! isempty (strfind (str, "using anovan instead")));
+%! assert_equal (! isempty (strfind (str, "using anovan instead")), true);
 %! assert_equal (stats.source, "anovan");
 %! assert_equal (atab{2, 1}, "Columns");
 %! assert_equal (atab{3, 1}, "Rows");

--- a/inst/Hypothesis_Testing/anova2.m
+++ b/inst/Hypothesis_Testing/anova2.m
@@ -173,7 +173,7 @@ function [p, anovatab, stats] = anova2 (x, reps, displayopt, model)
   if (reps > 1)
     xcells = reshape (x, reps, FFGn, SFGn);
     xdev = bsxfun (@minus, xcells, mean (xcells, 1));
-    cell_sse = squeeze (sum (xdev .^ 2, 1));
+    cell_sse = squeeze (sumsq (xdev, 1));
     SSE = sum (cell_sse.'(:));
   else
     SSE = SST - SSC - SSR;

--- a/inst/Hypothesis_Testing/anova2.m
+++ b/inst/Hypothesis_Testing/anova2.m
@@ -34,6 +34,9 @@
 ## @item
 ## @var{x} contains the data and it must be a matrix of at least two columns and
 ## two rows.
+## @code{NaN} observations are omitted.  If the remaining observations do not
+## form a balanced two-way design, @code{anova2} warns and delegates the fit to
+## @code{anovan}.
 ##
 ## @item
 ## @var{reps} is the number of replicates for each combination of factor groups.
@@ -104,10 +107,6 @@ function [p, anovatab, stats] = anova2 (x, reps, displayopt, model)
   if (nargin < 1 || nargin >4)
     error ("anova2: invalid number of input arguments.");
   endif
-  ## Check for NaN values in X
-  if (any (isnan ( x(:))))
-    error ("anova2: NaN values in input are not allowed.  Use anovan instead.");
-  endif
   ## Add defaults
   if (nargin == 1)
     reps = 1;
@@ -128,15 +127,26 @@ function [p, anovatab, stats] = anova2 (x, reps, displayopt, model)
   ## Check for valid repetitions
   if (! (int16 (FFGn) == FFGn))
     error ("anova2: the number of rows in X must be a multiple of REPS.");
-  else
-    idx_s = 1;
-    idx_e = reps;
-    for i = 1:FFGn
-      RIdx(i,:) = [idx_s:idx_e];
-      idx_s += reps;
-      idx_e += reps;
-    endfor
   endif
+
+  ## Remove NaNs when the remaining two-way design is still balanced.
+  if (any (isnan (x(:))))
+    [x, reps, balanced] = remove_nan_cells (x, reps, FFGn, SFGn);
+    if (! balanced)
+      [p, anovatab, stats] = anova2_anovan_fallback (x, reps, model, displayopt);
+      return;
+    endif
+    FFGn = size (x, 1) / reps;
+    SFGn = size (x, 2);
+  endif
+
+  idx_s = 1;
+  idx_e = reps;
+  for i = 1:FFGn
+    RIdx(i,:) = [idx_s:idx_e];
+    idx_s += reps;
+    idx_e += reps;
+  endfor
 
   ## Calculate group sample sizes
   GTsz = length (x(:));                 ## Number of total samples
@@ -333,6 +343,70 @@ function [p, anovatab, stats] = anova2 (x, reps, displayopt, model)
   endif
 endfunction
 
+function [x, reps, balanced] = remove_nan_cells (x, reps, FFGn, SFGn)
+
+  xcells = reshape (x, reps, FFGn, SFGn);
+  valid = ! isnan (xcells);
+  cell_counts = squeeze (sum (valid, 1));
+  balanced = all (cell_counts(:) == cell_counts(1));
+
+  if (! balanced)
+    return;
+  endif
+
+  reps = cell_counts(1);
+  if (reps == 0)
+    balanced = false;
+    return;
+  endif
+
+  x_clean = zeros (reps * FFGn, SFGn);
+  for i = 1:FFGn
+    rows = (i - 1) * reps + (1:reps);
+    for j = 1:SFGn
+      vals = xcells(:, i, j);
+      x_clean(rows, j) = vals(! isnan (vals));
+    endfor
+  endfor
+  x = x_clean;
+
+endfunction
+
+function [p, anovatab, stats] = anova2_anovan_fallback (x, reps, model, displayopt)
+
+  [y, col_group, row_group] = anova2_unroll_groups (x, reps);
+  switch (lower (model))
+    case {'interaction', 'full'}
+      model = 'full';
+    case 'linear'
+      model = 'linear';
+    otherwise
+      error (strcat ("anova2: NaN removal created an unbalanced design;", ...
+                     " nested fallback is not supported."));
+  endswitch
+
+  warning (strcat ("anova2: NaN removal created an unbalanced design;", ...
+                   " using anovan instead."));
+  [p, anovatab, stats] = anovan (y, {col_group, row_group}, ...
+                                 'model', model, ...
+                                 'display', displayopt, ...
+                                 'varnames', {'Columns', 'Rows'});
+
+endfunction
+
+function [y, col_group, row_group] = anova2_unroll_groups (x, reps)
+
+  FFGn = size (x, 1) / reps;
+  SFGn = size (x, 2);
+  xcells = reshape (x, reps, FFGn, SFGn);
+  [~, row_idx, col_idx] = ndgrid (1:reps, 1:FFGn, 1:SFGn);
+  valid = ! isnan (xcells);
+  y = xcells(valid);
+  col_group = col_idx(valid);
+  row_group = row_idx(valid);
+
+endfunction
+
 
 %!demo
 %!
@@ -426,3 +500,23 @@ endfunction
 %! assert_equal (atab{3,5}, 9.25800729165627, 1e-10);
 %! assert_equal (atab{2,6}, 0.141597630656771, 1e-10);
 %! assert_equal (atab{3,6}, 0.000636643812875719, 1e-10);
+
+%!test
+%! ## Balanced NaN removal keeps anova2 calculations on the balanced design.
+%! x = [NaN NaN; 2 5; 3 6; NaN NaN; 8 8; 10 9];
+%! xclean = [2 5; 3 6; 8 8; 10 9];
+%! [p, atab, stats] = anova2 (x, 3, 'off');
+%! [p2, atab2, stats2] = anova2 (xclean, 2, 'off');
+%! assert_equal (p, p2, 1e-12);
+%! assert_equal (atab, atab2);
+%! assert_equal (stats.source, "anova2");
+%! assert_equal (stats.df, stats2.df);
+
+%!test
+%! ## Unbalanced NaN removal follows MATLAB guidance and uses anovan.
+%! x = [1 NaN; 2 5; 3 6; 4 7; 8 8; 10 9];
+%! str = evalc ("[p, atab, stats] = anova2 (x, 3, 'off');");
+%! assert (! isempty (strfind (str, "using anovan instead")));
+%! assert_equal (stats.source, "anovan");
+%! assert_equal (atab{2, 1}, "Columns");
+%! assert_equal (atab{3, 1}, "Rows");

--- a/inst/Hypothesis_Testing/anovan.m
+++ b/inst/Hypothesis_Testing/anovan.m
@@ -1027,8 +1027,8 @@ function [P, T, STATS, TERMS] = anovan (Y, GROUP, varargin)
           I = 1 + find (row(i,:));
           df(Nm+i) = prod (df(I-1));
           termcols(1+Nm+i) = prod (df(I-1) + 1);
-          tmp = ones (n,1);
-          for j = 1:numel (I);
+          tmp = X{I(1)};
+          for j = 2:numel (I);
             tmp = reshape (bsxfun (@times, ...
                            reshape (tmp, n, 1, columns (tmp)), ...
                            reshape (X{I(j)}, n, columns (X{I(j)}), 1)), ...
@@ -1779,3 +1779,13 @@ endfunction
 %! assert_equal (STATS.coeffs(3,6), 0.000572, 1e-06);
 %! assert_equal (STATS.coeffs(4,6), 2.86e-05, 1e-07);
 %! assert_equal (STATS.coeffs(5,6), 4.44e-06, 1e-08);
+
+## Interaction columns preserve factor-column ordering.
+%!test
+%! y = (1:12)';
+%! g1 = repmat ([1; 2; 3], 4, 1);
+%! g2 = kron ([1; 2], ones (6, 1));
+%! [~, ~, stats] = anovan (y, {g1, g2}, 'model', 'full', ...
+%!                         'display', 'off');
+%! assert_equal (stats.X(:,5), stats.X(:,2) .* stats.X(:,4));
+%! assert_equal (stats.X(:,6), stats.X(:,3) .* stats.X(:,4));

--- a/inst/Hypothesis_Testing/anovan.m
+++ b/inst/Hypothesis_Testing/anovan.m
@@ -96,7 +96,9 @@
 ## a scalar integer : representing the maximum interaction order
 ##
 ## @item
-## a matrix of term definitions : each row is a term and each column is a factor
+## a matrix of term definitions : each row is a term and each column is a
+## factor. Entries are nonnegative integer exponents. Exponents greater than
+## one are valid only for factors selected by @qcode{"continuous"}.
 ## @end itemize
 ##
 ## @example
@@ -104,6 +106,16 @@
 ## A two-way ANOVA with interaction would be: [1 0; 0 1; 1 1]
 ## @end example
 ##
+## @end itemize
+##
+## @code{[@dots{}] = anovan (@var{Y}, @var{GROUP}, "nested", @var{nested})}
+##
+## @itemize
+## @item
+## @var{nested} is an N-by-N logical matrix, where N is the number of factors.
+## A true entry @code{@var{nested}(i,j)} specifies that factor i is nested in
+## factor j. A factor may be nested in more than one parent. Nested factors
+## must be categorical and use the default contrasts.
 ## @end itemize
 ##
 ## @code{[@dots{}] = anovan (@var{Y}, @var{GROUP}, "sstype", @var{sstype})}
@@ -262,6 +274,7 @@ function [P, T, STATS, TERMS] = anovan (Y, GROUP, varargin)
     VARNAMES = [];
     CONTINUOUS = [];
     RANDOM = [];
+    NESTED = [];
     CONTRASTS = {};
     ALPHA = 0.05;
     WEIGHTS = [];
@@ -276,8 +289,7 @@ function [P, T, STATS, TERMS] = anovan (Y, GROUP, varargin)
         case 'random'
           RANDOM = value;
         case 'nested'
-          error (strcat ("anovan: nested ANOVA is not supported. Please use", ...
-                         " anova2 for fully balanced nested ANOVA designs."));
+          NESTED = value;
         case 'sstype'
           SSTYPE = value;
         case 'varnames'
@@ -326,6 +338,28 @@ function [P, T, STATS, TERMS] = anovan (Y, GROUP, varargin)
     endif
     cont_vec = false (1, N);
     cont_vec(CONTINUOUS) = true;
+    if (isempty (NESTED))
+      NESTED = false (N);
+    elseif (! (isnumeric (NESTED) || islogical (NESTED)) ...
+            || ! isequal (size (NESTED), [N, N]) ...
+            || any (! ismember (NESTED(:), [0, 1])) ...
+            || any (diag (NESTED)))
+      error (strcat ("anovan: NESTED must be an N-by-N logical matrix", ...
+                     " with a zero diagonal."));
+    else
+      NESTED = logical (NESTED);
+    endif
+    closure = NESTED;
+    for factor = 1:N
+      closure |= closure(:, factor) * closure(factor, :);
+    endfor
+    if (any (diag (closure)))
+      error ("anovan: NESTED factor relationships must be acyclic.");
+    endif
+    nested_factors = any (NESTED, 2)' | any (NESTED, 1);
+    if (any (cont_vec & nested_factors))
+      error ("anovan: nested factors must be categorical.");
+    endif
     if (isa (GROUP, "categorical"))
       for j = 1:N
         if (ismember (j, CONTINUOUS))
@@ -570,36 +604,29 @@ function [P, T, STATS, TERMS] = anovan (Y, GROUP, varargin)
           endfor
           TERMS = cell2mat (TERMS);
       endswitch
-      TERMS = logical (TERMS);
+      TERMS = double (TERMS);
     else
       ## Assume that the user provided a suitable matrix of term definitions
-      if (size (MODELTYPE, 2) > N)
+      if (size (MODELTYPE, 2) != N)
         error (msg);
       endif
-      if (! all (ismember (MODELTYPE(:), [0,1])))
+      if (! isnumeric (MODELTYPE) || any (! isfinite (MODELTYPE(:))) ...
+          || any (MODELTYPE(:) < 0) ...
+          || any (MODELTYPE(:) != fix (MODELTYPE(:))))
         error (strcat ("anovan: elements of the model terms", ...
-                       " matrix must be either 0 or 1."));
+                       " matrix must be nonnegative integers."));
       endif
-      TERMS = logical (MODELTYPE);
+      TERMS = double (MODELTYPE);
     endif
     ## Evaluate terms matrix
-    Ng = sum (TERMS, 2);
-    if (any (diff (Ng) < 0))
-      error (strcat ("anovan: the model terms matrix must list", ...
-                     " main effects above/before interactions."));
-    endif
+    TERMS(! any (TERMS > 0, 2), :) = [];
+    Ng = sum (TERMS > 0, 2);
     ## Drop terms that include interactions with factors specified as random effects.
-    drop = any (bsxfun (@and, TERMS(:,RANDOM), (Ng > 1)), 2);
+    drop = any (bsxfun (@and, TERMS(:,RANDOM) > 0, (Ng > 1)), 2);
     TERMS(drop, :) = [];
     Ng(drop) = [];
     ## Evaluate terms
-    Nm = sum (Ng == 1);
-    Nx = sum (Ng > 1);
-    Nt = Nm + Nx;
-    if (any (any (TERMS(1:Nm,:), 1) != any (TERMS, 1)))
-      error (strcat ("anovan: all factors involved in", ...
-                     " interactions must have a main effect"));
-    endif
+    Nt = rows (TERMS);
 
     ## Calculate total sum-of-squares
     ct  = sum (Y)^2 / n;   % correction term
@@ -627,8 +654,13 @@ function [P, T, STATS, TERMS] = anovan (Y, GROUP, varargin)
         ## Type II (partially sequential, or hierarchical) sums-of-squares
         ss = zeros (Nt,1);
         for j = 1:Nt
-          i = find (TERMS(j,:));
-          k = cat (1, 1, 1 + find (any (! TERMS(:,i),2)));
+          i = find (TERMS(j,:) > 0);
+          if (isequal (SSTYPE, 'h'))
+            excludes_term = any (TERMS(:,i) < TERMS(j,i), 2);
+          else
+            excludes_term = any (TERMS(:,i) != TERMS(j,i), 2);
+          endif
+          k = cat (1, 1, 1 + find (excludes_term));
           XS = cell2mat (X(k));
           [jnk, R1] = lmfit (XS, Y, W);
           k = cat (1, j+1, k);
@@ -652,7 +684,7 @@ function [P, T, STATS, TERMS] = anovan (Y, GROUP, varargin)
         error ("anovan: sstype value not supported.");
     endswitch
     ss = max (0, ss); # Truncate negative SS at 0
-    dfe = dft - sum (df);
+    dfe = n - rank (cell2mat (X));
     ms = ss ./ df;
     mse = sse / dfe;
     eta_sq = ss ./ sst;
@@ -668,19 +700,20 @@ function [P, T, STATS, TERMS] = anovan (Y, GROUP, varargin)
     T(end,1:3) = {'Total', sst, dft};
     formula = sprintf ("Y ~ 1");  # Initialize model formula
     for i = 1:Nt
-      str = sprintf ("%s*", VARNAMES{find (TERMS(i,:))});
-      T(i+1,1) = str(1:end-1);
+      str = mTermName (TERMS(i,:), VARNAMES, NESTED);
+      T(i+1,1) = str;
       ## Append model term to formula
       str = regexprep (str, "\\*", ':');
-      if (strcmp (str(end-1), ''''))
+      if (any (ismember (find (TERMS(i,:) > 0), RANDOM)))
         ## Random intercept term
-        formula = sprintf ("%s + (1|%s)", formula, str(1:end-2));
+        formula = sprintf ("%s + (1|%s)", formula, ...
+                           strrep (str, "'", ""));
         ## Remove statistics for random factors from the ANOVA table
         #T(RANDOM+1,4:7) = cell(1,4);
         #P(RANDOM) = NaN;
       else
         ## Fixed effect term
-        formula = sprintf ("%s + %s", formula, str(1:end-1));
+        formula = sprintf ("%s + %s", formula, str);
       endif
     endfor
 
@@ -690,7 +723,7 @@ function [P, T, STATS, TERMS] = anovan (Y, GROUP, varargin)
     se = sqrt (diag (ucov) * mse);
     t =  b ./ se;
     p = 2 * (1 - (tcdf (abs (t), dfe)));
-    coeff_stats = zeros (1 + sum (df), 4);
+    coeff_stats = zeros (1 + sum (df), 6);
     coeff_stats(:,1) = b;                                # coefficients
     coeff_stats(:,2) = se;                               # standard errors
     coeff_stats(:,3) = b - se * t_crit;                  # Lower CI bound
@@ -700,8 +733,9 @@ function [P, T, STATS, TERMS] = anovan (Y, GROUP, varargin)
     ## Assign NaN to p-value to avoid printing statistics relating to
     ## coefficients for 'random' effects
     hi = 1 + cumsum (df);
-    for ignore = RANDOM
-      p(hi(ignore)-df(ignore)+1:hi(ignore)) = NaN;
+    random_terms = find (any (TERMS(:,RANDOM) > 0, 2));
+    for ignore = random_terms'
+      coeff_stats(hi(ignore)-df(ignore)+1:hi(ignore), 6) = NaN;
     endfor
 
     ## Compute leverage values and Cook's distance
@@ -727,8 +761,8 @@ function [P, T, STATS, TERMS] = anovan (Y, GROUP, varargin)
                     'vars', [], ...          # Not used by Octave
                     'varnames', {VARNAMES}, ...
                     'grpnames', {levels}, ...
-                    'vnested', [], ...       # Not used since "nested" argument name is not supported
-                    'ems', [], ...           # Not used since "nested" argument name is not supported
+                    'vnested', NESTED, ...
+                    'ems', [], ...           # Expected mean squares are computed by anova
                     'denom', [], ...         # Not used since interactions with random factors is not supported
                     'dfdenom', [], ...       # Not used since interactions with random factors is not supported
                     'msdenom', [], ...       # Not used since interactions with random factors is not supported
@@ -910,174 +944,180 @@ function [P, T, STATS, TERMS] = anovan (Y, GROUP, varargin)
       ## Nested function that returns a cell array of the design matrix for
       ## each term in the model
       ## Input variables it uses:
-      ##  GROUP, TERMS, CONTINUOUS, CONTRASTS, VARNAMES, n, Nm, Nx, Ng
+      ##  GROUP, TERMS, CONTINUOUS, CONTRASTS, VARNAMES, n
       ## Variables it creates or modifies:
       ##  X, grpnames, nlevels, df, termcols, coeffnames, vmeans, gid, CONTRASTS
 
       ## EVALUATE FACTOR LEVELS
-      levels = cell (Nm, 1);
-      gid = zeros (n, Nm);
-      nlevels = zeros (Nm, 1);
-      df = zeros (Nm + Nx, 1);
-      termcols = ones (1 + Nm + Nx, 1);
-      for j = 1:Nm
-        if (any (j == CONTINUOUS))
-
-          ## CONTINUOUS PREDICTOR
+      levels = cell (N, 1);
+      gid = zeros (n, N);
+      nlevels = zeros (N, 1);
+      for j = 1:N
+        if (cont_vec(j))
           nlevels(j) = 1;
-          termcols(j+1) = 1;
-          df(j) = 1;
-          if iscell (GROUP(:,j))
+          if (iscell (GROUP(:,j)))
             gid(:,j) = cell2mat ([GROUP(:,j)]);
           else
             gid(:,j) = GROUP(:,j);
           endif
-
-        else
-
-          ## CATEGORICAL PREDICTOR
-          if (isempty (categorical_levels{j}))
-            levels{j} = unique (GROUP(:,j), 'stable');
-            if (isnumeric (levels{j}))
-              levels{j} = num2cell (levels{j});
-            endif
-            level_values = levels{j};
-            nlevels(j) = numel (level_values);
-            for k = 1:nlevels(j)
-              gid(ismember (GROUP(:,j), level_values{k}),j) = k;
-            endfor
-          else
-            if (iscell (GROUP))
-              codes = cell2mat (GROUP(:,j));
-            else
-              codes = GROUP(:,j);
-            endif
-            level_values = num2cell (find (accumarray (codes, 1) > 0));
-            levels{j} = categorical_levels{j}(cell2mat (level_values));
-            nlevels(j) = numel (level_values);
-            for k = 1:nlevels(j)
-              gid(codes == level_values{k},j) = k;
-            endfor
+        elseif (isempty (categorical_levels{j}))
+          levels{j} = unique (GROUP(:,j), 'stable');
+          if (isnumeric (levels{j}))
+            levels{j} = num2cell (levels{j});
           endif
-          termcols(j+1) = nlevels(j);
-          df(j) = nlevels(j) - 1;
-
+          nlevels(j) = numel (levels{j});
+          for k = 1:nlevels(j)
+            gid(ismember (GROUP(:,j), levels{j}{k}),j) = k;
+          endfor
+        else
+          if (iscell (GROUP))
+            codes = cell2mat (GROUP(:,j));
+          else
+            codes = GROUP(:,j);
+          endif
+          level_values = find (accumarray (codes, 1) > 0);
+          levels{j} = categorical_levels{j}(level_values);
+          nlevels(j) = numel (level_values);
+          for k = 1:nlevels(j)
+            gid(codes == level_values(k),j) = k;
+          endfor
         endif
       endfor
 
-      ## MAKE DESIGN MATRIX
-
-      ## MAIN EFFECTS
-      X = cell (1, 1 + Nm + Nx);
-      X(1) = ones (n, 1);
-      coeffnames = cell (1, 1 + Nm + Nx);
-      coeffnames(1) = '(Intercept)';
-      vmeans = zeros (Nm, 1);
+      ## ENCODE EACH FACTOR ONCE
+      base = cell (N, 1);
+      vmeans = zeros (N, 1);
       center_continuous = cont_vec;
-      for j = 1:Nm
-        if (any (j == CONTINUOUS))
-
-          ## CONTINUOUS PREDICTOR
-          if iscell (GROUP(:,j))
-            X(1+j) = cell2mat (GROUP(:,j));
-          else
-            X(1+j) = GROUP(:,j);
-          endif
-          if (strcmpi (CONTRASTS{j}, 'treatment'))
-            ## Don't center continuous variables if contrasts are 'treatment'
+      for j = 1:N
+        if (cont_vec(j))
+          base{j} = gid(:,j);
+          if (ischar (CONTRASTS{j}) ...
+              && strcmpi (CONTRASTS{j}, 'treatment'))
             center_continuous(j) = false;
             CONTRASTS{j} = [];
           else
-            center_continuous(j) = true;
-            vmeans(j) = mean ([X{1+j}]);
-            X(1+j) = [X{1+j}] - vmeans(j);
+            vmeans(j) = mean (base{j});
+            base{j} -= vmeans(j);
           endif
-          ## Create names of the coefficients relating to continuous main effects
-          coeffnames{1+j} = VARNAMES{j};
-
-        else
-
-          ## CATEGORICAL PREDICTOR
-          if (nlevels(j) == 1)
-            CONTRASTS{j} = zeros (1, 0);
-          elseif (isempty (CONTRASTS{j}))
-            CONTRASTS{j} = contr_simple (nlevels(j));
-          else
-            switch (lower (CONTRASTS{j}))
-              case {'simple','anova'}
-                ## SIMPLE EFFECT CODING (DEFAULT)
-                ## The first level is the reference level
-                CONTRASTS{j} = contr_simple (nlevels(j));
-              case 'poly'
-                ## POLYNOMIAL CONTRAST CODING
-                CONTRASTS{j} = contr_poly (nlevels(j));
-              case 'helmert'
-                ## HELMERT CONTRAST CODING
-                CONTRASTS{j} = contr_helmert (nlevels(j));
-              case 'effect'
-                ## DEVIATION EFFECT CONTRAST CODING
-                CONTRASTS{j} = contr_sum (nlevels(j));
-              case {'sdif','sdiff'}
-                ## SUCCESSIVE DEVIATIONS CONTRAST CODING
-                CONTRASTS{j} = contr_sdif (nlevels(j));
-              case 'treatment'
-                ## The first level is the reference level
-                CONTRASTS{j} = contr_treatment (nlevels(j));
-              otherwise
-                ## EVALUATE CUSTOM CONTRAST MATRIX
-                ## Check that the contrast matrix provided is the correct size
-                if (! all (size (CONTRASTS{j},1) == nlevels(j)))
-                  error (strcat ("anovan: the number of rows in the", ...
-                                 " contrast matrices should equal the", ...
-                                 " number of factor levels."));
-                endif
-                if (! all (size (CONTRASTS{j},2) == df(j)))
-                  error (strcat ("anovan: the number of columns in each", ...
-                                 " contrast matrix should equal the degrees", ...
-                                 " of freedom (i.e. number of levels minus", ...
-                                 " 1) for that factor."));
-                endif
-                if (! all (any (CONTRASTS{j})))
-                  error (strcat ("anovan: a contrast must be coded in each", ...
-                                 " column of the contrast matrices."));
-                endif
-            endswitch
+        elseif (any (NESTED(j,:)))
+          if (! isempty (CONTRASTS{j}))
+            error (strcat ("anovan: custom contrasts are not supported", ...
+                           " for nested factors."));
           endif
-          C = CONTRASTS{j};
-          X{1+j} = C(gid(:,j), :);
-          ## Create names of the coefficients relating to continuous main effects
-          coeffnames{1+j} = cell (df(j),1);
-          for v = 1:df(j)
-            coeffnames{1+j}{v} = sprintf ("%s_%u", VARNAMES{j}, v);
+          parents = find (NESTED(j,:));
+          [~, ~, parent_id] = unique (gid(:,parents), 'rows');
+          blocks = cell (max (parent_id), 1);
+          for parent = 1:max (parent_id)
+            rows_ = find (parent_id == parent);
+            child_levels = unique (gid(rows_,j), 'stable');
+            [~, local_id] = ismember (gid(rows_,j), child_levels);
+            C = contr_simple (numel (child_levels));
+            block = zeros (n, columns (C));
+            block(rows_,:) = C(local_id,:);
+            blocks{parent} = block;
           endfor
-
+          base{j} = cell2mat (blocks');
+          CONTRASTS{j} = [];
+        else
+          CONTRASTS{j} = mContrasts (CONTRASTS{j}, nlevels(j));
+          base{j} = CONTRASTS{j}(gid(:,j), :);
         endif
       endfor
 
-      ## INTERACTION TERMS
-      if (Nx > 0)
-        row = TERMS((Ng > 1),:);
-        for i = 1:Nx
-          I = 1 + find (row(i,:));
-          df(Nm+i) = prod (df(I-1));
-          termcols(1+Nm+i) = prod (df(I-1) + 1);
-          tmp = X{I(1)};
-          for j = 2:numel (I);
-            tmp = reshape (bsxfun (@times, ...
-                           reshape (tmp, n, 1, columns (tmp)), ...
-                           reshape (X{I(j)}, n, columns (X{I(j)}), 1)), ...
-                           n, []);
-          endfor
-          X{1+Nm+i} = tmp;
-          coeffnames{1+Nm+i} = cell (df(Nm+i),1);
-          for v = 1:df(Nm+i)
-            str = sprintf ("%s:", VARNAMES{I-1});
-            coeffnames{1+Nm+i}{v} = strcat (str(1:end-1), "_", num2str (v));
-          endfor
+      ## BUILD ONE DESIGN BLOCK FOR EACH REQUESTED TERM
+      X = cell (1, Nt + 1);
+      X{1} = ones (n, 1);
+      coeffnames = cell (1, Nt + 1);
+      coeffnames{1} = '(Intercept)';
+      df = zeros (Nt, 1);
+      termcols = ones (Nt + 1, 1);
+      for i = 1:Nt
+        factors = find (TERMS(i, :) > 0);
+        tmp = ones (n, 1);
+        for j = factors
+          exponent = TERMS(i, j);
+          if (! cont_vec(j) && exponent != 1)
+            error (strcat ("anovan: categorical factors cannot have", ...
+                           " exponent values greater than 1."));
+          endif
+          block = base{j};
+          if (cont_vec(j) && exponent != 1)
+            block = block .^ exponent;
+          endif
+          tmp = reshape (bsxfun (@times, ...
+                         reshape (tmp, n, 1, columns (tmp)), ...
+                         reshape (block, n, columns (block), 1)), n, []);
         endfor
-      endif
+        X{i + 1} = tmp;
+        df(i) = columns (tmp);
+        termcols(i + 1) = columns (tmp);
+        term_name = mTermName (TERMS(i, :), VARNAMES, NESTED);
+        if (df(i) == 1)
+          coeffnames{i + 1} = term_name;
+        else
+          coeffnames{i + 1} = arrayfun (...
+            @(v) sprintf ("%s_%u", term_name, v), (1:df(i))', ...
+            'UniformOutput', false);
+        endif
+      endfor
 
     endfunction
+
+endfunction
+
+function C = mContrasts (specification, nlevels)
+
+  if (nlevels == 1)
+    C = zeros (1, 0);
+  elseif (isempty (specification))
+    C = contr_simple (nlevels);
+  elseif (ischar (specification))
+    switch (lower (specification))
+      case {'simple', 'anova'}
+        C = contr_simple (nlevels);
+      case 'poly'
+        C = contr_poly (nlevels);
+      case 'helmert'
+        C = contr_helmert (nlevels);
+      case 'effect'
+        C = contr_sum (nlevels);
+      case {'sdif', 'sdiff'}
+        C = contr_sdif (nlevels);
+      case 'treatment'
+        C = contr_treatment (nlevels);
+      otherwise
+        error ("anovan: unknown contrast specification.");
+    endswitch
+  else
+    C = specification;
+    if (! isequal (size (C), [nlevels, nlevels - 1]))
+      error (strcat ("anovan: each contrast matrix must have one row per", ...
+                     " factor level and one fewer column."));
+    elseif (! all (any (C)))
+      error ("anovan: a contrast must be coded in every column.");
+    endif
+  endif
+
+endfunction
+
+function name = mTermName (term, varnames, nested)
+
+  pieces = cell (1, nnz (term));
+  count = 0;
+  for j = find (term > 0)
+    count += 1;
+    factor = varnames{j};
+    if (nargin > 2 && any (nested(j,:)))
+      parents = strrep (varnames(nested(j,:)), "'", "");
+      factor = sprintf ("%s(%s)", factor, strjoin (parents, ","));
+    endif
+    if (term(j) == 1)
+      pieces{count} = factor;
+    else
+      pieces{count} = sprintf ("%s^%d", factor, term(j));
+    endif
+  endfor
+  name = strjoin (pieces, "*");
 
 endfunction
 
@@ -1858,3 +1898,65 @@ endfunction
 %! assert_equal (tbl, tbl_ref);
 %! assert_equal (stats.grpnames{1}, {'3'; '1'});
 %! assert_equal (stats.Y, [1; 2; 4; 5]);
+
+## Terms matrices select factors by column rather than row position.
+%!test
+%! A = [1; 1; 2; 2];
+%! B = [1; 2; 1; 2];
+%! y = 100 * A + B;
+%! [~, tbl, stats, terms] = anovan (y, {A, B}, 'model', [0, 1], ...
+%!                                  'display', 'off');
+%! assert_equal (terms, [0, 1]);
+%! assert_equal (tbl{2, 1}, 'X2');
+%! assert_equal (tbl{2, 2}, 1, 1e-12);
+%! assert_equal (full (stats.X(:, 2)), [-0.5; 0.5; -0.5; 0.5]);
+
+## Reordering terms changes Type I order without relabeling their columns.
+%!test
+%! A = [1; 1; 2; 2];
+%! B = [1; 2; 1; 2];
+%! y = 100 * A + B;
+%! [~, tbl] = anovan (y, {A, B}, 'model', [0, 1; 1, 0], ...
+%!                    'sstype', 1, 'display', 'off');
+%! assert_equal (tbl(2:3, 1), {'X2'; 'X1'});
+%! assert_equal (cell2mat (tbl(2:3, 2)), [1; 10000], 1e-10);
+
+## Continuous exponent terms are evaluated element-wise.
+%!test
+%! x = (-2:2)';
+%! y = 2 + 3 * x + 4 * x .^ 2;
+%! [~, ~, stats, terms] = anovan (y, x, 'model', [1; 2], ...
+%!                                  'continuous', 1, 'display', 'off');
+%! assert_equal (terms, [1; 2]);
+%! assert_equal (full (stats.X(:, 2)), x);
+%! assert_equal (full (stats.X(:, 3)), x .^ 2);
+%! assert_equal (stats.resid, zeros (5, 1), 1e-12);
+
+%!error <categorical factors cannot have exponent> ...
+%! anovan ((1:4)', {[1; 1; 2; 2], [1; 2; 1; 2]}, ...
+%!         'model', [2, 0], 'display', 'off')
+
+%!error <NESTED must be an N-by-N logical matrix> ...
+%! anovan ((1:4)', {[1; 1; 2; 2], [1; 2; 1; 2]}, ...
+%!         'nested', [0, 1], 'display', 'off')
+
+%!error <NESTED must be an N-by-N logical matrix> ...
+%! anovan ((1:4)', {[1; 1; 2; 2], [1; 2; 1; 2]}, ...
+%!         'nested', [0, 2; 0, 0], 'display', 'off')
+
+%!error <NESTED must be an N-by-N logical matrix> ...
+%! anovan ((1:4)', {[1; 1; 2; 2], [1; 2; 1; 2]}, ...
+%!         'nested', eye (2), 'display', 'off')
+
+%!error <NESTED factor relationships must be acyclic> ...
+%! anovan ((1:4)', {[1; 1; 2; 2], [1; 2; 1; 2]}, ...
+%!         'nested', [0, 1; 1, 0], 'display', 'off')
+
+%!error <nested factors must be categorical> ...
+%! anovan ((1:4)', {[1; 1; 2; 2], [1; 2; 1; 2]}, ...
+%!         'nested', [0, 0; 1, 0], 'continuous', 1, 'display', 'off')
+
+%!error <custom contrasts are not supported for nested factors> ...
+%! anovan ((1:8)', [kron([1; 2], ones(4, 1)), ...
+%!         repmat([1; 1; 2; 2], 2, 1)], 'nested', [0, 0; 1, 0], ...
+%!         'contrasts', {[]; [-0.5; 0.5]}, 'display', 'off')

--- a/inst/Hypothesis_Testing/anovan.m
+++ b/inst/Hypothesis_Testing/anovan.m
@@ -311,6 +311,8 @@ function [P, T, STATS, TERMS] = anovan (Y, GROUP, varargin)
     ## of strings or numeric identifiers
     N = size (GROUP, 2); # number of anova "ways"
     n = numel (Y);       # total number of observations
+    categorical_levels = cell (1, N);
+    categorical_missing = false (n, 1);
     if (prod (size (Y)) != n)
       error ("anovan: for ""anovan (Y, GROUP)"", Y must be a vector.");
     endif
@@ -324,11 +326,27 @@ function [P, T, STATS, TERMS] = anovan (Y, GROUP, varargin)
     endif
     cont_vec = false (1, N);
     cont_vec(CONTINUOUS) = true;
-    if (iscell (GROUP))
+    if (isa (GROUP, "categorical"))
+      for j = 1:N
+        if (ismember (j, CONTINUOUS))
+          error ("anovan: continuous factors must be a numeric datatype.");
+        endif
+        categorical_levels{j} = categories (GROUP(:,j));
+        categorical_missing |= isundefined (GROUP(:,j));
+      endfor
+      GROUP = double (GROUP);
+    elseif (iscell (GROUP))
       if (size (GROUP, 1) == 1)
         tmp = cell (n, N);
         for j = 1:N
-          if (isnumeric (GROUP{j}))
+          if (isa (GROUP{j}, "categorical"))
+            if (ismember (j, CONTINUOUS))
+              error ("anovan: continuous factors must be a numeric datatype.");
+            endif
+            categorical_levels{j} = categories (GROUP{j});
+            categorical_missing |= isundefined (GROUP{j}(:));
+            tmp(:,j) = num2cell (double (GROUP{j}(:)));
+          elseif (isnumeric (GROUP{j}))
             if (ismember (j, CONTINUOUS))
               tmp(:,j) = num2cell (GROUP{j});
             else
@@ -468,7 +486,8 @@ function [P, T, STATS, TERMS] = anovan (Y, GROUP, varargin)
       if iscell (XC)
         XC = cell2mat (XC);
       endif
-      excl = any ([isnan(Y), isinf(Y), any(isnan(XC),2), any(isinf(XC),2)], 2);
+      excl = any ([isnan(Y), isinf(Y), any(isnan(XC),2), any(isinf(XC),2)], 2) ...
+             | categorical_missing;
       GROUP(excl,:) = [];
     endif
     Y(excl) = [];
@@ -917,14 +936,29 @@ function [P, T, STATS, TERMS] = anovan (Y, GROUP, varargin)
         else
 
           ## CATEGORICAL PREDICTOR
-          levels{j} = unique (GROUP(:,j), 'stable');
-          if isnumeric (levels{j})
-            levels{j} = num2cell (levels{j});
+          if (isempty (categorical_levels{j}))
+            levels{j} = unique (GROUP(:,j), 'stable');
+            if (isnumeric (levels{j}))
+              levels{j} = num2cell (levels{j});
+            endif
+            level_values = levels{j};
+            nlevels(j) = numel (level_values);
+            for k = 1:nlevels(j)
+              gid(ismember (GROUP(:,j), level_values{k}),j) = k;
+            endfor
+          else
+            if (iscell (GROUP))
+              codes = cell2mat (GROUP(:,j));
+            else
+              codes = GROUP(:,j);
+            endif
+            level_values = num2cell (find (accumarray (codes, 1) > 0));
+            levels{j} = categorical_levels{j}(cell2mat (level_values));
+            nlevels(j) = numel (level_values);
+            for k = 1:nlevels(j)
+              gid(codes == level_values{k},j) = k;
+            endfor
           endif
-          nlevels(j) = numel (levels{j});
-          for k = 1:nlevels(j)
-            gid(ismember (GROUP(:,j),levels{j}{k}),j) = k;
-          endfor
           termcols(j+1) = nlevels(j);
           df(j) = nlevels(j) - 1;
 
@@ -964,7 +998,9 @@ function [P, T, STATS, TERMS] = anovan (Y, GROUP, varargin)
         else
 
           ## CATEGORICAL PREDICTOR
-          if (isempty (CONTRASTS{j}))
+          if (nlevels(j) == 1)
+            CONTRASTS{j} = zeros (1, 0);
+          elseif (isempty (CONTRASTS{j}))
             CONTRASTS{j} = contr_simple (nlevels(j));
           else
             switch (lower (CONTRASTS{j}))
@@ -1008,9 +1044,7 @@ function [P, T, STATS, TERMS] = anovan (Y, GROUP, varargin)
             endswitch
           endif
           C = CONTRASTS{j};
-          func = @(x) x(gid(:,j));
-          X(1+j) = cell2mat (cellfun (func, num2cell (C, 1), ...
-                                      'UniformOutput', false));
+          X{1+j} = C(gid(:,j), :);
           ## Create names of the coefficients relating to continuous main effects
           coeffnames{1+j} = cell (df(j),1);
           for v = 1:df(j)
@@ -1789,3 +1823,38 @@ endfunction
 %!                         'display', 'off');
 %! assert_equal (stats.X(:,5), stats.X(:,2) .* stats.X(:,4));
 %! assert_equal (stats.X(:,6), stats.X(:,3) .* stats.X(:,4));
+
+## Full six-factor interactions preserve every model term.
+%!test
+%! n = 128;
+%! group = cell (1, 6);
+%! for k = 1:6
+%!   group{k} = mod (floor ((0:n-1)' / 2^(k-1)), 2) + 1;
+%! endfor
+%! [p, ~, stats, terms] = anovan ((1:n)', group, 'model', 'full', ...
+%!                                'display', 'off');
+%! assert_equal (rows (terms), 63);
+%! assert_equal (columns (stats.X), 64);
+%! assert_equal (numel (p), 63);
+
+## A one-level factor has no estimable main effect.
+%!test
+%! group = ones (3, 1);
+%! [p, tbl, stats] = anovan ((1:3)', group, ...
+%!                          'sstype', 2, 'display', 'off');
+%! assert_equal (p, NaN);
+%! assert_equal (tbl{2, 2}, 0);
+%! assert_equal (tbl{2, 3}, 0);
+%! assert_equal (tbl{2, 6}, NaN);
+%! assert_equal (size (stats.X), [3, 1]);
+
+## Categorical factors retain their declared order and omit missing observations.
+%!test
+%! group = categorical ([3; 3; NaN; 1; 1], [3, 2, 1]);
+%! [p, tbl, stats] = anovan ((1:5)', group, 'sstype', 2, 'display', 'off');
+%! [p_ref, tbl_ref] = anovan ([1; 2; 4; 5], [1; 1; 2; 2], ...
+%!                           'sstype', 2, 'display', 'off');
+%! assert_equal (p, p_ref, 1e-12);
+%! assert_equal (tbl, tbl_ref);
+%! assert_equal (stats.grpnames{1}, {'3'; '1'});
+%! assert_equal (stats.Y, [1; 2; 4; 5]);

--- a/inst/Hypothesis_Testing/anovan.m
+++ b/inst/Hypothesis_Testing/anovan.m
@@ -1029,11 +1029,10 @@ function [P, T, STATS, TERMS] = anovan (Y, GROUP, varargin)
           termcols(1+Nm+i) = prod (df(I-1) + 1);
           tmp = ones (n,1);
           for j = 1:numel (I);
-            tmp = num2cell (tmp, 1);
-            for k = 1:numel (tmp)
-              tmp(k) = bsxfun (@times, tmp{k}, X{I(j)});
-            endfor
-            tmp = cell2mat (tmp);
+            tmp = reshape (bsxfun (@times, ...
+                           reshape (tmp, n, 1, columns (tmp)), ...
+                           reshape (X{I(j)}, n, columns (X{I(j)}), 1)), ...
+                           n, []);
           endfor
           X{1+Nm+i} = tmp;
           coeffnames{1+Nm+i} = cell (df(Nm+i),1);


### PR DESCRIPTION
## Summary

- vectorize grouped ANOVA calculations and improve missing-data routing
- add polynomial, nested, and random-factor model support with expected mean squares and variance components
- align the class interface, result tables, documentation, plots, and validation with MATLAB behavior
- remove the unreachable LinearModel-backed constructor path after LinearModel.anova was merged
- strengthen BISTs with assert_equal, schemas, dimensions, and numeric references

## Testing

- anova: 117/117
- anova1: 10/10
- anova2: 5/5
- anovan: 26/26
- LinearModel: 369/369
- verified anova(mdl) dispatches to LinearModel.anova and returns a table