### PR TITLE
fix lasso Intercept/Standardize interaction bug

### DIFF
--- a/inst/Regression/lasso.m
+++ b/inst/Regression/lasso.m
@@ -153,6 +153,11 @@ function [B, FitInfo] = lasso (X, y, varargin)
   if (! isempty (lambda) && (! isnumeric (lambda) || any (lambda < 0)))
     error ("lasso: 'Lambda' must be a vector of non-negative values.");
   endif
+  if (! intercept && standardize)
+    warning (["lasso: when the 'Intercept' value is false, the " ...
+              "'Standardize' value is set to false."]);
+    standardize = false;
+  endif
 
   ## Drop observations with missing values.
   ok = ! (any (isnan (X), 2) | isnan (y));
@@ -433,6 +438,9 @@ endfunction
 %! [~, I] = lasso (X, y, "CV", 4, "MCReps", 2);
 %! thr = I.MSE(I.IndexMinMSE) + I.SE(I.IndexMinMSE);
 %! assert_equal (I.MSE(I.Index1SE) <= thr + 1e-9, true);
+
+%!warning <lasso: when the 'Intercept' value is false, the 'Standardize' value is set to false.> ...
+%! lasso (X, y, "Lambda", 0.1, "Intercept", false);
 
 ## Test input validation
 %!error <Invalid call to lasso> lasso (1)


### PR DESCRIPTION
when Intercept is set to false, Standardize is now automatically forced to false too (with a warning), instead of silently standardizing predictors and producing a different, wrong coefficient.

Before 
```
octave:3> X = [0.1; 0.4; 0.35; 0.8; 0.65; 0.2; 0.55; 0.9; 0.05; 0.7];
octave:4> y = [0.3; 1.1; 0.9; 1.9; 1.5; 0.5; 1.4; 2.2; 0.15; 1.6];
octave:5> B = lasso(X, y, 'Lambda', 1e-3, 'Intercept', false)
B = 2.4173
```
After 
```
octave:3> X = [0.1; 0.4; 0.35; 0.8; 0.65; 0.2; 0.55; 0.9; 0.05; 0.7];
octave:4> y = [0.3; 1.1; 0.9; 1.9; 1.5; 0.5; 1.4; 2.2; 0.15; 1.6];
octave:5> B = lasso(X, y, 'Lambda', 1e-3, 'Intercept', false)
warning: lasso: when the 'Intercept' value is false, the 'Standardize' value is set to false.
warning: called from
    lasso at line 157 column 5

B = 2.4158
```
MATLAB : 
```
>> X = [0.1; 0.4; 0.35; 0.8; 0.65; 0.2; 0.55; 0.9; 0.05; 0.7];

>> y = [0.3; 1.1; 0.9; 1.9; 1.5; 0.5; 1.4; 2.2; 0.15; 1.6];

>> B = lasso(X, y, 'Lambda', 1e-3, 'Intercept', false)

Warning: When the 'Intercept' value is false, the 'Standardize' value is set to false. 
> In lasso (line 142) 

B =

    2.4158
```


