### PR TITLE
Fix partialcorr zero-residual detection for collinear controlling variables.

### DIFF
--- a/inst/Descriptive_Statistics/partialcorr.m
+++ b/inst/Descriptive_Statistics/partialcorr.m
@@ -234,7 +234,9 @@ function [r, nu] = resid_partial (a, b, C, Type, Rows, completerows)
   rb = b - M * (M \ b);
   sa = sqrt (sum (ra .^ 2));
   sb = sqrt (sum (rb .^ 2));
-  if (sa == 0 || sb == 0)
+  tol_a = m * eps (max (abs (a)));
+  tol_b = m * eps (max (abs (b)));
+  if (sa <= tol_a || sb <= tol_b)
     r = NaN;
   else
     r = sum (ra .* rb) / (sa * sb);
@@ -346,6 +348,17 @@ endfunction
 %! assert_equal (rc, [-0.0116; -0.5849], 1e-4);
 %! assert_equal (rp, [-0.0116; -0.5273], 1e-4);
 %! assert_equal (pp, [0.9764; 0.1173], 1e-4);
+
+## a controlling variable that perfectly explains a column of X collapses
+## its residual variance, so rho and pval are NaN
+%!test
+%! X = [1 2; 3 4; 5 5];
+%! Z = [2; 4; 6];
+%! [rho, pval] = partialcorr (X, Z);
+%! assert_equal (isnan (rho(1,:)), [true, true]);
+%! assert_equal (isnan (rho(:,1)), [true; true]);
+%! assert_equal (rho(2,2), 1);
+%! assert_equal (all (isnan (pval(:))), true);
 
 ## input validation
 %!error <partialcorr: invalid number of input matrices.> ...


### PR DESCRIPTION
Fixed partialcorr to return NaN when a controlling variable perfectly explains one of the correlated variables, instead of silently computing a meaningless number.

BEFORE:
```
octave:12> X = [1 2; 3 4; 5 5];
octave:13> Z = [2; 4; 6];
octave:14> [rho, pval] = partialcorr(X, Z)
rho =

   1.000000  -0.089087
  -0.089087   1.000000

pval =

   NaN   NaN
   NaN   NaN
```
AFTER: 
```
octave:25> X = [1 2; 3 4; 5 5];
octave:26> Z = [2; 4; 6];
octave:27> [rho, pval] = partialcorr(X, Z)
rho =

   NaN   NaN
   NaN     1

pval =

   NaN   NaN
   NaN   NaN
```
MATLAB : 
```
>> X = [1 2; 3 4; 5 5];

>> Z = [2; 4; 6];

>> [rho, pval] = partialcorr(X, Z)

rho =

   NaN   NaN
   NaN     1


pval =

   NaN   NaN
   NaN   NaN

```