### PR TITLE
Fix `dwtest` producing meaningless p-value when n equals rank(x)

### DIFF
--- a/inst/Hypothesis_Testing/dwtest.m
+++ b/inst/Hypothesis_Testing/dwtest.m
@@ -122,7 +122,11 @@ function [pval, d] = dwtest (r, x, varargin)
   A -= diag (ones (n-1, 1), 1) + diag (ones (n-1, 1), -1);
 
   ## Lower-tail probability P(D <= d) under the null hypothesis
-  if (strcmp (method, "exact"))
+  if (n - p <= 0)
+    ## No residual degrees of freedom: the null distribution of D collapses
+    ## to a point, so any observed D is treated as arbitrarily extreme
+    plow = 0;
+  elseif (strcmp (method, "exact"))
     M = eye (n) - Q * Q';
     MAM = M * A * M;
     nu = sort (eig ((MAM + MAM') / 2), "descend");
@@ -219,6 +223,13 @@ endfunction
 %! x = [ones(20, 1), (1:20)'];
 %! r = (-1) .^ (1:20)';
 %! assert_equal (dwtest (r, x, "Tail", "left") < 0.05, true);
+
+%!test  # zero residual degrees of freedom (n == rank(x))
+%! x = [1 0 0; 0 1 0; 0 0 1];
+%! r = [0.5; -0.3; 0.8];
+%! assert_equal (dwtest (r, x, "Tail", "right"), 0);
+%! assert_equal (dwtest (r, x, "Tail", "left"), 1);
+%! assert_equal (dwtest (r, x, "Tail", "both"), 0);
 
 ## Test input validation
 %!error <Invalid call to dwtest> dwtest (1)


### PR DESCRIPTION
dwtest now correctly returns 0/1 p-values instead of a meaningless 0.5 when the design matrix uses up all degrees of freedom (n == rank(x))
BEFORE: 
```
octave:17> x = [1 0 0; 0 1 0; 0 0 1];
octave:18> r = [0.5; -0.3; 0.8];
octave:19> [p, d] = dwtest(r, x, 'Tail', 'right')
p = 0.5000
d = 1.8878
```
AFTER:
```
octave:3> x = [1 0 0; 0 1 0; 0 0 1];
octave:4> r = [0.5; -0.3; 0.8];
octave:5> [p, d] = dwtest(r, x, 'Tail', 'right')
p = 0
d = 1.8878
```
MATLAB:
```
>> x = [1 0 0; 0 1 0; 0 0 1];

>> r = [0.5; -0.3; 0.8];

>> [p, d] = dwtest(r, x, 'Tail', 'right')

p =

     0


d =

    1.8878
```