### PR TITLE
Fix `nanvar` behavior on empty multidimensional arrays to match MATLAB

### DIFF
--- a/inst/Descriptive_Statistics/nanstd.m
+++ b/inst/Descriptive_Statistics/nanstd.m
@@ -92,6 +92,11 @@ endfunction
 %!assert_equal (nanstd ([1 2 NaN; 4 NaN 6; 7 8 9; 10 11 12], 0, 2), ...
 %!        sqrt ([0.5; 2; 1; 1]), 1e-14)
 %!assert_equal (nanstd (NaN (2, 3)), [NaN, NaN, NaN])
+%!assert_equal (nanstd (zeros (0, 3)), [NaN, NaN, NaN])
+%!assert_equal (nanstd (zeros (3, 0)), zeros (1, 0))
+%!assert_equal (nanstd ([], 1), NaN)
+%!assert_equal (nanstd ([], [], 1), zeros (1, 0))
+%!assert_equal (size (nanstd (ones (2, 0, 3, 2), 0, 2)), [2, 1, 3, 2])
 
 ## Test input validation
 %!error <Invalid call to nanstd> nanstd ()

--- a/inst/Descriptive_Statistics/nanvar.m
+++ b/inst/Descriptive_Statistics/nanvar.m
@@ -62,7 +62,7 @@ function v = nanvar (x, w, dim)
   if (! isnumeric (x) && ! islogical (x))
     error ("nanvar: X must be numeric.");
   endif
-  if (isempty (x))
+  if ((nargin < 2 || (nargin == 2 && isempty (w))) && isempty (x) && ndims (x) == 2 && size (x, 1) == 0 && size (x, 2) == 0)
     v = NaN;
     return;
   endif

--- a/inst/Descriptive_Statistics/nanvar.m
+++ b/inst/Descriptive_Statistics/nanvar.m
@@ -62,7 +62,7 @@ function v = nanvar (x, w, dim)
   if (! isnumeric (x) && ! islogical (x))
     error ("nanvar: X must be numeric.");
   endif
-  if ((nargin < 2 || (nargin == 2 && isempty (w))) && isempty (x) && ndims (x) == 2 && size (x, 1) == 0 && size (x, 2) == 0)
+  if (nargin < 3 && isequal (size (x), [0, 0]))
     v = NaN;
     return;
   endif
@@ -184,6 +184,11 @@ endfunction
 %!assert_equal (nanvar ([1 2 NaN; 4 NaN 6; 7 8 9; 10 11 12], [1 2 3 4]'), ...
 %!        [9, 8.4375, 50/9], 1e-13)
 %!assert_equal (nanvar (NaN (2, 3)), [NaN, NaN, NaN])
+%!assert_equal (nanvar (zeros (0, 3)), [NaN, NaN, NaN])
+%!assert_equal (nanvar (zeros (3, 0)), zeros (1, 0))
+%!assert_equal (nanvar ([], 1), NaN)
+%!assert_equal (nanvar ([], [], 1), zeros (1, 0))
+%!assert_equal (size (nanvar (ones (2, 0, 3, 2), 0, 2)), [2, 1, 3, 2])
 %!test
 %! x = reshape (1:24, [2, 4, 3]);
 %! x([5:6, 20]) = NaN;


### PR DESCRIPTION
**Before (Octave):**
```matlab
>> nanvar(zeros(0, 3))
   NaN
## Size: [1 1]

>> nanvar(ones(2, 0, 3, 2), 0, 2)
   NaN
## Size: [1 1]
```

**After (Octave) & MATLAB Expected Behavior:**
```matlab
>> nanvar(zeros(0, 3))
   NaN   NaN   NaN
## Size: [1 3]

>> nanvar(ones(2, 0, 3, 2), 0, 2)
## Size: [2 1 3 2] containing NaNs
```