### PR TITLE
Fix `datasample` to support `k=0` empty array returns

### DIFF
--- a/inst/Data_Manipulation/datasample.m
+++ b/inst/Data_Manipulation/datasample.m
@@ -65,9 +65,9 @@ function [y, idcs] = datasample (data, k, varargin)
     error ("datasample: data must be a vector or matrix");
   endif
 
-  ## k, a positive integer
-  if ((! isnumeric (k) || ! isscalar (k)) || (! (floor (k) == k)) || (k <= 0))
-    error ("datasample: k must be a positive integer scalar");
+  ## k, a non-negative integer
+  if ((! isnumeric (k) || ! isscalar (k)) || (! (floor (k) == k)) || (k < 0))
+    error ("datasample: k must be a non-negative integer scalar");
   endif
 
   dim = 1;
@@ -123,7 +123,9 @@ function [y, idcs] = datasample (data, k, varargin)
     ## this is easy
 
     ## with or without replacement
-    if (replace)
+    if (k == 0)
+      idcs = zeros (0, 1);
+    elseif (replace)
       idcs = randi (imax, k, 1);
     else
       idcs = randperm (imax, k);
@@ -135,6 +137,7 @@ function [y, idcs] = datasample (data, k, varargin)
     endif
 
     if (replace)
+      idcs = zeros (k, 1);
       ## easy case:
       ## normalize the weights,
       weights_n = cumsum (weights ./ sum (weights));
@@ -150,6 +153,7 @@ function [y, idcs] = datasample (data, k, varargin)
       endfor
     else
       ## complex case
+      idcs = zeros (1, k);
       if (k > imax)
         error (strcat ("datasample: K must not exceed the number of", ...
                        " available elements when sampling without replacement."));
@@ -210,10 +214,10 @@ endfunction
 %!error datasample ();
 %!error datasample (1);
 %!error <data must be a vector or matrix> datasample ({1, 2, 3}, 1);
-%!error <k must be a positive integer scalar> datasample ([1 2], -1);
-%!error <k must be a positive integer scalar> datasample ([1 2], 1.5);
-%!error <k must be a positive integer scalar> datasample ([1 2], [1 1]);
-%!error <k must be a positive integer scalar> datasample ([1 2], 'g', [1 1]);
+%!error <k must be a non-negative integer scalar> datasample ([1 2], -1);
+%!error <k must be a non-negative integer scalar> datasample ([1 2], 1.5);
+%!error <k must be a non-negative integer scalar> datasample ([1 2], [1 1]);
+%!error <k must be a non-negative integer scalar> datasample ([1 2], 'g', [1 1]);
 %!error <DIM must be a positive integer scalar> datasample ([1 2], 1, -1);
 %!error <DIM must be a positive integer scalar> datasample ([1 2], 1, 1.5);
 %!error <DIM must be a positive integer scalar> datasample ([1 2], 1, [1 1]);
@@ -236,4 +240,9 @@ endfunction
 %!test
 %! dat = randn (10, 4);
 %! assert_equal (size (datasample (dat, 3, 2)), [10 3]);
+
+%!test
+%! ## Edge cases with empty arrays and k=0
+%! assert_equal (datasample ([], 0), zeros (0, 0));
+%! assert_equal (datasample (zeros (0, 3), 0), zeros (0, 3));
 


### PR DESCRIPTION
In MATLAB, calling `datasample(data, 0)` returns an empty array that preserves the non-sampled dimensions of the input data (e.g., `datasample(zeros(0,3), 0)` returns a `0x3` array). In Octave, passing `k=0` throws a validation error: `k must be a positive integer scalar`. So this is fixed now via this pr.